### PR TITLE
Add test to see if PubSub item can be deleted

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/pubsub/PubSubIntegrationTest.java
@@ -911,7 +911,8 @@ public class PubSubIntegrationTest extends AbstractSmackIntegrationTest {
 
             // Retrieve items and assert that the item that was just deleted is no longer among them.
             final List<Item> items = node.getItems();
-            assertFalse(items.stream().anyMatch(item -> item.getId().equals(needle)));
+            assertFalse(items.stream().anyMatch(item -> item.getId().equals(needle)),
+                "After deleting item '" + needle + "' it was expected that this item no longer was returned in a request for items of node '" + nodename + "' (but it was).");
         } finally {
             pubSubManagerOne.deleteNode(nodename);
         }


### PR DESCRIPTION
XEP-0060 defines optional functionality to delete items from a node. This commit adds a test for this, that's only executed when the corresponding feature is announced through service discovery.

As an aside, this tests the fix for Openfire's OF-2791 issue.