### PR TITLE
Increase minimum Java version from 8 to 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 11, 17 ]
         distribution: [ temurin ] # We could add more here: temurin, adopt, liberica, microsoft, corretto
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: mvn package
       - name: Stash the built artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.java == 8}}
+        if: ${{ matrix.java == 11}}
         with:
           name: smack-tests
           path: target/smack-sint-server-extensions-*-jar-with-dependencies.jar

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Additional tests that are server-oriented to add to those in [Smack's Integratio
 
 ## Run tests
 
-These tests require **Java 8 or later** to execute.
+These tests require **Java 11 or later** to execute.
 
 The tests from this project can be executed using any of the following methods.
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Upstream, Smack's integration-test module is now compiled with Java 11. Lets follow suit.