### PR TITLE
Upgrade junit dependency from 4.12 to 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
4.12 has been reported to include a CVE. No functional changes are expected to be introduced in our project by this upgrade.