### PR TITLE
Add ability to store XMPP logs in files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,3 +91,8 @@ jobs:
           -DlogDir=logs \
           -jar $JARFILE
         shell: bash
+      - name: Expose XMPP debug logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: XMPP debug logs
+          path: logs/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,5 +87,7 @@ jobs:
           -Dsinttest.enabledConnections=tcp \
           -Dsinttest.dnsResolver=javax \
           -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest" \
+          -Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory" \
+          -DlogDir=logs \
           -jar $JARFILE
         shell: bash

--- a/README.md
+++ b/README.md
@@ -41,3 +41,19 @@ This is the most basic configuration that you can use to run tests against a loc
 ### From source code, on the command line
 
 To run the tests directly from the source code, edit the pom.xml to match your settings, then run `mvn exec:java`
+
+### Log XMPP traffic in files
+
+A Smack Debugger implementation is included, that, once configured, will store debug logs (containing XMPP traffic) in distinct files, per test that's executed.
+
+To enable this logging, this system property is to be added to the invocation of these tests:
+
+```bash
+-Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory"
+```
+
+An additional system property can be used to identify the directory in which the logs are to be stored. This directory will be created, if it doesn't already exist.
+
+```bash
+-DlogDir=target/logs
+```

--- a/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
@@ -50,7 +50,7 @@ public class FileLogger extends AbstractDebugger
         if (testUnderExecution != null) {
             filename = testUnderExecution.toString();
         } else {
-            filename = "output";
+            filename = "test_suite_orchestration";
         }
         filename += ".log";
 

--- a/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
@@ -1,0 +1,79 @@
+package org.igniterealtime.smack.inttest.util;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestFramework;
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.debugger.AbstractDebugger;
+import org.jivesoftware.smack.debugger.SmackDebugger;
+import org.jivesoftware.smack.debugger.SmackDebuggerFactory;
+import org.jivesoftware.smack.util.ExceptionUtil;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class FileLogger extends AbstractDebugger
+{
+    private final SimpleDateFormat dateFormatter = new SimpleDateFormat("HH:mm:ss.S");
+    private final Path logDir;
+
+    public FileLogger(XMPPConnection connection) {
+        super(connection);
+
+        final String logDir = System.getProperty("logDir");
+        if (logDir != null) {
+            final Path logDirPath = Paths.get(logDir);
+            try {
+                Files.createDirectories(logDirPath);
+            } catch (IOException e) {
+                throw new IllegalStateException("Logging location does not exist or is not writable: " + logDirPath.toAbsolutePath(), e);
+            }
+            this.logDir = logDirPath;
+            System.out.println("Saving debug logs in " + logDirPath.toAbsolutePath());
+        } else {
+            this.logDir = null;
+        }
+    }
+
+    @Override
+    protected void log(String logMessage) {
+        String formatedDate;
+        synchronized (dateFormatter) {
+            formatedDate = dateFormatter.format(new Date());
+        }
+
+        String filename;
+        final SmackIntegrationTestFramework.ConcreteTest testUnderExecution = SmackIntegrationTestFramework.getTestUnderExecution();
+        if (testUnderExecution != null) {
+            filename = testUnderExecution.toString();
+        } else {
+            filename = "output";
+        }
+        filename += ".log";
+
+        Path logPath;
+        if (logDir != null) {
+            logPath = logDir.resolve(filename);
+        } else {
+            logPath = Paths.get(filename);
+        }
+
+        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(logPath.toFile(), true), StandardCharsets.UTF_8);
+             final BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
+            bufferedWriter.write(formatedDate + ' ' + logMessage + System.lineSeparator());
+        } catch (IOException e) {
+            System.err.println("Unable to write log to file " + filename);
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void log(String logMessage, Throwable throwable) {
+        String stacktrace = ExceptionUtil.getStackTrace(throwable);
+        log(logMessage + '\n' + stacktrace);
+    }
+
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/util/FileLoggerFactory.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/FileLoggerFactory.java
@@ -1,0 +1,20 @@
+package org.igniterealtime.smack.inttest.util;
+
+import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.debugger.SmackDebugger;
+import org.jivesoftware.smack.debugger.SmackDebuggerFactory;
+
+public final class FileLoggerFactory implements SmackDebuggerFactory
+{
+    public static final SmackDebuggerFactory INSTANCE = new FileLoggerFactory();
+
+    public FileLoggerFactory()
+    {
+    }
+
+    @Override
+    public SmackDebugger create(XMPPConnection connection) throws IllegalArgumentException
+    {
+        return new FileLogger(connection);
+    }
+}


### PR DESCRIPTION
This adds a new Smack debug logger that can be used to store XMPP traffic in distinct files per test.

To configure the logger, use these system properties when invoking the tests:

```
-Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory"
-DlogDir=target/logs
```

The `logDir` property value is used to identify the directory in which the logs will be stored. The directory will be created if it doesn't already exist.