### PR TITLE
Use SINT 'host' configuration option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,12 @@ jobs:
         with:
           name: XMPP debug logs
           path: logs/*
+      - name: Expose Openfire logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: Openfire server logs
+          path: openfire/logs/*
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: always() # always run even if the previous step fails

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,9 +79,9 @@ jobs:
           # Borrowing from:
           #  - https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-action/blob/main/action.yml
           #  - https://github.com/igniterealtime/Openfire/blob/ddf144c4ff3b0f753c4087c1e197dfc2bab324a9/.github/workflows/continuous-integration-workflow.yml#L199-L205
-          sudo echo "127.0.0.1 example.org" | sudo tee -a /etc/hosts
           java \
           -Dsinttest.service="example.org" \
+          -Dsinttest.host="127.0.0.1" \
           -Dsinttest.securityMode=disabled \
           -Dsinttest.replyTimeout=5000 \
           -Dsinttest.adminAccountUsername=admin \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           cache: maven
       - name: Build with Maven # We install instead of package, because we want the result in the local mvn repo
-        run: mvn package
+        run: mvn --update-snapshots package
       - name: Stash the built artifacts
         uses: actions/upload-artifact@v4
         if: ${{ matrix.java == 11}}

--- a/pom.xml
+++ b/pom.xml
@@ -125,11 +125,6 @@
         </dependency>
         <dependency>
             <groupId>org.igniterealtime.smack</groupId>
-            <artifactId>smack-websocket</artifactId>
-            <version>${smack.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.igniterealtime.smack</groupId>
             <artifactId>smack-xmlparser-stax</artifactId>
             <version>${smack.version}</version>
         </dependency>


### PR DESCRIPTION
Recently, the Smack Integration Test Framework got a new configuration option, named 'host'. This allows the test to be configured with an IP address or DNS name of the XMPP service to run the tests on.

This new option negates the tricks involving setting `/etc/hosts` to make the XMPP domain name resolve to the intended host. This commit replaces that solution with the new configuration option.