### PR TITLE
Add tests for XEP-0215 External Service Discovery

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/ExternalServiceDiscoveryIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/ExternalServiceDiscoveryIntegrationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0215;
+
+import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.xep0215.packet.DiscoverExternalServices;
+import org.igniterealtime.smack.inttest.xep0215.packet.ServiceCredentials;
+import org.igniterealtime.smack.inttest.xep0215.provider.DiscoverExternalServicesProvider;
+import org.igniterealtime.smack.inttest.xep0215.provider.ServiceCredentialsProvider;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.provider.ProviderManager;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
+import org.jxmpp.jid.DomainBareJid;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.text.ParseException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpecificationReference(document = "XEP-0215", version = "1.0.0")
+public class ExternalServiceDiscoveryIntegrationTest extends AbstractSmackIntegrationTest
+{
+    public static final String NAMESPACE = "urn:xmpp:extdisco:2";
+
+    private final DomainBareJid service;
+
+    public ExternalServiceDiscoveryIntegrationTest(SmackIntegrationTestEnvironment environment) throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+
+        service = ServiceDiscoveryManager.getInstanceFor(environment.conOne).findService(NAMESPACE, true);
+        if (service == null) {
+            throw new TestNotPossibleException("Unable to find any service on domain that supports XEP-0215 External Service Discovery.");
+        }
+
+        ProviderManager.addIQProvider(DiscoverExternalServices.ELEMENT, DiscoverExternalServices.NAMESPACE, new DiscoverExternalServicesProvider());
+        ProviderManager.addIQProvider(ServiceCredentials.ELEMENT, ServiceCredentials.NAMESPACE, new ServiceCredentialsProvider());
+    }
+
+    @SmackIntegrationTest(section = "2", quote = "expires - A timestamp indicating when the provided username and password credentials will expire. The format MUST adhere to the dateTime format specified in XMPP Date and Time Profiles (XEP-0082) [...] .")
+    public void requestAllExpiryTimestampsValidTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException, TestNotPossibleException
+    {
+        final DiscoverExternalServices request = new DiscoverExternalServices();
+        request.setTo(service);
+
+        final DiscoverExternalServices response = conOne.sendIqRequestAndWaitForResponse(request);
+        final Collection<String> discoveredExpiryDates = response.getServices().stream().map(DiscoverExternalServices.Service::getExpires).filter(Objects::nonNull).collect(Collectors.toSet());
+        if (discoveredExpiryDates.isEmpty()) {
+            throw new TestNotPossibleException("The server under test does not provide any data that has en 'expires' value.");
+        }
+
+        final Set<String> invalidFormat = new HashSet<>();
+        for (final String discoveredExpiryDate : discoveredExpiryDates) {
+            try {
+                ParserUtils.getDateFromXep82String(discoveredExpiryDate);
+            } catch (ParseException e) {
+                invalidFormat.add(discoveredExpiryDate);
+            }
+        }
+
+        assertTrue(invalidFormat.isEmpty(), "Expected all 'expires' timestamps received by '" + conOne + "' from '" + service + "' to be in the dateTime format specified in XMPP Date and Time Profiles (XEP-0082), but these values were not: " + String.join(", ", invalidFormat));
+    }
+
+    @SmackIntegrationTest(section = "2", quote = "expires - A timestamp indicating when the provided username and password credentials will expire. The format [...] MUST be expressed in UTC.")
+    public void requestAllExpiryTimestampsZuluTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException, TestNotPossibleException
+    {
+        final DiscoverExternalServices request = new DiscoverExternalServices();
+        request.setTo(service);
+
+        final DiscoverExternalServices response = conOne.sendIqRequestAndWaitForResponse(request);
+        final Collection<String> discoveredExpiryDates = response.getServices().stream().map(DiscoverExternalServices.Service::getExpires).filter(Objects::nonNull).collect(Collectors.toSet());
+        if (discoveredExpiryDates.isEmpty()) {
+            throw new TestNotPossibleException("The server under test does not provide any data that has en 'expires' value.");
+        }
+
+        final String[] zuluEndings = new String[] { "z", "Z", "+00:00", "-00:00"};
+        final Set<String> notUTC = new HashSet<>();
+        for (final String discoveredExpiryDate : discoveredExpiryDates) {
+            if (Arrays.stream(zuluEndings).noneMatch(discoveredExpiryDate::endsWith)) {
+                notUTC.add(discoveredExpiryDate);
+            }
+        }
+
+        assertTrue(notUTC.isEmpty(), "Expected all 'expires' timestamps received by '" + conOne + "' from '" + service + "' to be expressed in UTC, but these values were not: " + String.join(", ", notUTC));
+    }
+
+    @SmackIntegrationTest(section = "3.1", quote = "A requesting entity requests all services by sending a <services/> element to its server or a discovery service.")
+    public void requestAllServicesTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException
+    {
+        final DiscoverExternalServices request = new DiscoverExternalServices();
+        request.setTo(service);
+
+        final IQ response = conOne.sendIqRequestAndWaitForResponse(request);
+        assertTrue(response instanceof DiscoverExternalServices, "Expected a request for all services to return a valid response (but it did not).");
+    }
+
+    @SmackIntegrationTest(section = "3.2", quote = "A requesting entity requests services of a particular type by sending a <services/> element including a 'type' attribute specifying the service type of interest.")
+    public void requestSelectedServicesTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException, TestNotPossibleException
+    {
+        final DiscoverExternalServices request = new DiscoverExternalServices();
+        request.setTo(service);
+
+        final DiscoverExternalServices response = conOne.sendIqRequestAndWaitForResponse(request);
+        final List<DiscoverExternalServices.Service> discoveredServices = response.getServices();
+        if (discoveredServices.isEmpty()) {
+            throw new TestNotPossibleException("The server under test does not provide any data. Cannot request selected services (while expecting a non-empty response).");
+        }
+
+        final Map<String, List<DiscoverExternalServices.Service>> servicesByTypes = discoveredServices.stream().collect(Collectors.groupingBy(DiscoverExternalServices.Service::getType));
+        for (final Map.Entry<String, List<DiscoverExternalServices.Service>> servicesByType : servicesByTypes.entrySet()) {
+            final String type = servicesByType.getKey();
+            final List<DiscoverExternalServices.Service> expectedServices = servicesByType.getValue();
+
+            final DiscoverExternalServices requestSelected = new DiscoverExternalServices();
+            requestSelected.setTo(service);
+            requestSelected.setServiceType(type);
+
+            final DiscoverExternalServices selectedResponse = conOne.sendIqRequestAndWaitForResponse(requestSelected);
+            final List<DiscoverExternalServices.Service> actualServices = selectedResponse.getServices();
+            assertEquals(type, selectedResponse.getServiceType(), "Expected the response to a request for services of a particular type to echo back that type in the child element of the response (but it did not).");
+
+            assertTrue(expectedServices.size() == actualServices.size() && expectedServices.containsAll(actualServices) && actualServices.containsAll(expectedServices),
+                "When querying for services of type '" + type + "', the response is expected to be equal to all services from the scope-less response of that type. Expected: " + expectedServices + " Actual: " + actualServices);
+        }
+    }
+
+    @SmackIntegrationTest(section = "3.3", quote = "The entity can request credentials by sending a special request to the server composed of a <credentials/> element qualified by the 'urn:xmpp:extdisco:2' namespace and contains a <service/> element.")
+    public void requestServiceCredentialsTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException, TestNotPossibleException
+    {
+        final DiscoverExternalServices request = new DiscoverExternalServices();
+        request.setTo(service);
+
+        final DiscoverExternalServices response = conOne.sendIqRequestAndWaitForResponse(request);
+        final List<DiscoverExternalServices.Service> discoveredServices = response.getServices();
+        if (discoveredServices.isEmpty()) {
+            throw new TestNotPossibleException("The server under test does not provide any data. Cannot request credentials for a service (as there do not appear to be any in existence).");
+        }
+
+        // We can't predict if the response that we get is one that includes an error or not. We'll only assert that any response can be parsed and thus seems syntactically correct.
+        final DiscoverExternalServices.Service firstDiscoveredService = discoveredServices.get(0);
+        final ServiceCredentials credentialsRequest = new ServiceCredentials(firstDiscoveredService.getHost(), firstDiscoveredService.getType(), firstDiscoveredService.getPort());
+        credentialsRequest.setTo(service);
+        final IQ credentialsResponse = conOne.sendIqRequestAndWaitForResponse(credentialsRequest);
+        assertTrue(credentialsResponse instanceof ServiceCredentials, "Expected a request for credentials to return a response (but it did not).");
+    }
+
+    @SmackIntegrationTest(section = "3.3", quote = "If the server cannot obtain credentials at the service, it returns an appropriate stanza error [...]")
+    public void requestServiceCredentialsNonExistingServiceTest() throws SmackException.NotConnectedException, InterruptedException, XMPPException.XMPPErrorException, SmackException.NoResponseException, TestNotPossibleException, XmppStringprepException
+    {
+        final String server = "doesntexist"+StringUtils.randomString(4);
+        final ServiceCredentials request = new ServiceCredentials(server, "test");
+        request.setTo(service);
+
+        try {
+            conOne.sendIqRequestAndWaitForResponse(request);
+            fail("Expected a request made by '" + conOne + "' to '" + service + "' for credentials of a non-exising service ('" + server + "') to be responded to with an IQ error response (but it did not).");
+        } catch (XMPPException.XMPPErrorException e) {
+            // Expected to catch this Exception. We cannot be certain what error condition is returned, so there's no explicit assertion for that.
+        }
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/package-info.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integration Tests for the XEP-0215: External Service Discovery
+ */
+package org.igniterealtime.smack.inttest.xep0215;

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/DiscoverExternalServices.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/DiscoverExternalServices.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0215.packet;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+
+import java.util.*;
+
+/**
+ * Ab 'external service discovery' stanza implementation, as defined by XEP-0215, which represents a list of
+ * discovered services.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0215.html">XEP-0215: External Service Discovery</a>
+ */
+public class DiscoverExternalServices extends IQ
+{
+    public static final String ELEMENT = "services";
+    public static final String NAMESPACE = "urn:xmpp:extdisco:2";
+
+    private final List<Service> services = new LinkedList<>();
+
+    private String serviceType = null;
+
+    public DiscoverExternalServices() {
+        super(ELEMENT, NAMESPACE);
+    }
+
+    /**
+     * Returns the type of the service to which this request pertains (eg: 'turn').
+     *
+     * This method returns null when the request is not scoped to a particular service type.
+     *
+     * @return the optional service type.
+     */
+    public String getServiceType()
+    {
+        return serviceType;
+    }
+
+    /**
+     * Defines the type of the service to which this request pertains (eg: 'turn').
+     *
+     * @param serviceType A type of service
+     */
+    public void setServiceType(String serviceType)
+    {
+        this.serviceType = serviceType;
+    }
+
+    /**
+     * Adds a new service to the discovered information.
+     *
+     * @param service the discovered service
+     */
+    public void addService(final Service service) {
+        services.add(service);
+    }
+
+    /**
+     * Adds a collection of services to the discovered information.
+     *
+     * This method does nothing if the provided argument is null.
+     *
+     * @param servicesToAdd the discovered services
+     */
+    public void addServices(final Collection<Service> servicesToAdd) {
+        if (servicesToAdd != null) {
+            this.services.addAll(servicesToAdd);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable list of all services that are part of the discovered information.
+     *
+     * @return A list of services (possibly empty, never null).
+     */
+    public List<Service> getServices() {
+        return Collections.unmodifiableList(services);
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.optAttribute("type", getServiceType());
+        xml.rightAngleBracket();
+        services.forEach(service -> xml.append(service.toXML()));
+        return xml;
+    }
+
+    /**
+     * Representation of a discovered 'service' as defined by XEP-0215.
+     */
+    public static class Service
+    {
+        public static final String ELEMENT = "service";
+
+        public enum Action {
+            add, delete, modify
+        }
+
+        /**
+         * When sending a push update, the action value indicates if the service is being added or deleted from the set
+         * of known services (or simply being modified).
+         *
+         * The defined values are "add", "remove", and "modify", where "add" is the default.
+         */
+        private Action action;
+
+        /**
+         * A timestamp indicating when the provided username and password credentials will expire. The format MUST
+         * adhere to the dateTime format specified in XMPP Date and Time Profiles (XEP-0082) and MUST be expressed in
+         * UTC.
+         */
+        private String expires;
+
+        /**
+         * Either a fully qualified domain name (FQDN) or an IP address (IPv4 or IPv6).
+         */
+        private final String host;
+
+        /**
+         * A friendly (human-readable) name or label for the service.
+         */
+        private String name;
+
+        /**
+         * A service- or server-generated password for use at the service.
+         */
+        private String password;
+
+        /**
+         * The communications port to be used at the host.
+         */
+        private Integer port;
+
+        /**
+         * A boolean value indicating that username and password credentials are required and will need to be requested
+         * if not already provided
+         */
+        private Boolean restricted;
+
+        /**
+         * The underlying transport protocol to be used when communicating with the service (typically either TCP or UDP).
+         */
+        private String transport;
+
+        /**
+         * The service type as registered with the XMPP Registrar.
+         */
+        private final String type;
+
+        /**
+         * A service- or server-generated username for use at the service.
+         */
+        private String username;
+
+        /**
+         * Extended information added by the server or service.
+         */
+        private DataForm dataForm;
+
+        public Service(String host, String type)
+        {
+            this.host = host;
+            this.type = type;
+        }
+
+        public Action getAction()
+        {
+            return action;
+        }
+
+        public void setAction(Action action)
+        {
+            this.action = action;
+        }
+
+        public String getExpires()
+        {
+            return expires;
+        }
+
+        public void setExpires(String expires)
+        {
+            this.expires = expires;
+        }
+
+        public String getHost()
+        {
+            return host;
+        }
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(String name)
+        {
+            this.name = name;
+        }
+
+        public String getPassword()
+        {
+            return password;
+        }
+
+        public void setPassword(String password)
+        {
+            this.password = password;
+        }
+
+        public Integer getPort()
+        {
+            return port;
+        }
+
+        public void setPort(Integer port)
+        {
+            this.port = port;
+        }
+
+        public Boolean isRestricted()
+        {
+            return restricted;
+        }
+
+        public void setRestricted(Boolean restricted)
+        {
+            this.restricted = restricted;
+        }
+
+        public String getTransport()
+        {
+            return transport;
+        }
+
+        public void setTransport(String transport)
+        {
+            this.transport = transport;
+        }
+
+        public String getType()
+        {
+            return type;
+        }
+
+        public String getUsername()
+        {
+            return username;
+        }
+
+        public void setUsername(String username)
+        {
+            this.username = username;
+        }
+
+        public DataForm getDataForm()
+        {
+            return dataForm;
+        }
+
+        public void setDataForm(DataForm dataForm)
+        {
+            this.dataForm = dataForm;
+        }
+
+        public XmlStringBuilder toXML() {
+            XmlStringBuilder xml = new XmlStringBuilder();
+            xml.halfOpenElement("service");
+            xml.optAttribute("action", action);
+            xml.optAttribute("expires", expires);
+            xml.attribute("host", host);
+            xml.optAttribute("name", name);
+            xml.optAttribute("password", password);
+            xml.optAttribute("port", port);
+            if (restricted != null) {
+                xml.optAttribute("restricted", Boolean.toString(restricted));
+            }
+            xml.optAttribute("transport", transport);
+            xml.attribute("type", type);
+            xml.optAttribute("username", username);
+            xml.optAppend(dataForm);
+
+            xml.closeEmptyElement();
+            return xml;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Service service = (Service) o;
+            return action == service.action && Objects.equals(expires, service.expires) && Objects.equals(host, service.host) && Objects.equals(name, service.name) && Objects.equals(password, service.password) && Objects.equals(port, service.port) && Objects.equals(restricted, service.restricted) && Objects.equals(transport, service.transport) && Objects.equals(type, service.type) && Objects.equals(username, service.username) && Objects.equals(dataForm, service.dataForm);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(action, expires, host, name, password, port, restricted, transport, type, username, dataForm);
+        }
+
+        @Override
+        public String toString() {
+            return toXML().toString();
+        }
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/ServiceCredentials.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/ServiceCredentials.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0215.packet;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+
+import java.util.*;
+
+/**
+ * Ab 'external service discovery' stanza implementation, as defined by XEP-0215, which represents a list of
+ * discovered services.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0215.html">XEP-0215: External Service Discovery</a>
+ */
+public class ServiceCredentials extends IQ
+{
+    public static final String ELEMENT = "credentials";
+    public static final String NAMESPACE = "urn:xmpp:extdisco:2";
+
+    private final List<Service> services = new LinkedList<>();
+
+    public ServiceCredentials(final String host, final String type) {
+        this(host, type, null);
+    }
+
+    public ServiceCredentials(final String host, final String type, final Integer port) {
+        super(ELEMENT, NAMESPACE);
+        final Service service = new Service(host, type);
+        service.setPort(port);
+        services.add(service);
+    }
+
+    public void addService(final Service service) {
+        services.add(service);
+    }
+
+    public void addServices(final Collection<Service> servicesToAdd) {
+        if (servicesToAdd != null) {
+            this.services.addAll(servicesToAdd);
+        }
+    }
+
+    /**
+     * Returns an unmodifiable list of all services that are part of the discovered information.
+     *
+     * @return A list of services (possibly empty, never null).
+     */
+    public List<Service> getServices() {
+        return Collections.unmodifiableList(services);
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.rightAngleBracket();
+        services.forEach(service -> xml.append(service.toXML()));
+        return xml;
+    }
+
+    /**
+     * Representation of a discovered 'service' as defined by XEP-0215.
+     */
+    public static class Service
+    {
+        public static final String ELEMENT = "service";
+
+        private final String host;
+
+        private final String type;
+
+        private Integer port;
+
+        private String password;
+
+        private String username;
+
+        private DataForm dataForm;
+
+        public Service(String host, String type)
+        {
+            this.host = host;
+            this.type = type;
+        }
+
+        public String getHost()
+        {
+            return host;
+        }
+
+        public String getType()
+        {
+            return type;
+        }
+
+        public Integer getPort()
+        {
+            return port;
+        }
+
+        public void setPort(Integer port)
+        {
+            this.port = port;
+        }
+
+        public String getPassword()
+        {
+            return password;
+        }
+
+        public void setPassword(String password)
+        {
+            this.password = password;
+        }
+
+        public String getUsername()
+        {
+            return username;
+        }
+
+        public void setUsername(String username)
+        {
+            this.username = username;
+        }
+
+        public DataForm getDataForm()
+        {
+            return dataForm;
+        }
+
+        public void setDataForm(DataForm dataForm)
+        {
+            this.dataForm = dataForm;
+        }
+
+        public XmlStringBuilder toXML() {
+            XmlStringBuilder xml = new XmlStringBuilder();
+            xml.halfOpenElement("service");
+            xml.attribute("host", host);
+            xml.attribute("type", type);
+            xml.optAttribute("port", port);
+            xml.optAttribute("password", password);
+            xml.optAttribute("username", username);
+            xml.optAppend(dataForm);
+
+            xml.closeEmptyElement();
+            return xml;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Service service = (Service) o;
+            return Objects.equals(host, service.host) && Objects.equals(type, service.type) && Objects.equals(port, service.port) && Objects.equals(password, service.password) && Objects.equals(username, service.username) && Objects.equals(dataForm, service.dataForm);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(host, type, port, password, username, dataForm);
+        }
+
+        @Override
+        public String toString() {
+            return toXML().toString();
+        }
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/package-info.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/packet/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Stanza representation for XEP-0215: External Service Discovery
+ */
+package org.igniterealtime.smack.inttest.xep0215.packet;

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/DiscoverExternalServicesProvider.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/DiscoverExternalServicesProvider.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0215.provider;
+
+import org.igniterealtime.smack.inttest.xep0215.packet.DiscoverExternalServices;
+import org.jivesoftware.smack.packet.IqData;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.provider.IqProvider;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+/**
+ * A provider for DiscoverExternalServices stanzas.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0215.html">XEP-0215: External Service Discovery</a>
+ */
+public class DiscoverExternalServicesProvider extends IqProvider<DiscoverExternalServices>
+{
+    public DiscoverExternalServices parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
+        throws XmlPullParserException, IOException
+    {
+        final DiscoverExternalServices result = new DiscoverExternalServices();
+        boolean done = false;
+        DiscoverExternalServices.Service service;
+        DiscoverExternalServices.Service.Action action = null;
+        String expiresString = null; // Leaving this as a string rather than a date, as we want to test the raw String in an integration test.
+        String host = null;
+        String name = null;
+        String password = null;
+        Integer port = null;
+        Boolean restricted = null;
+        String transport = null;
+        String type = null;
+        String username = null;
+
+        result.setServiceType(parser.getAttributeValue("type"));
+        while (!done)
+        {
+            final XmlPullParser.Event eventType = parser.next();
+
+            if (eventType == XmlPullParser.Event.START_ELEMENT && DiscoverExternalServices.Service.ELEMENT.equals(parser.getName()))
+            {
+                // Initialize the variables from the parsed XML
+                final String actionVal = parser.getAttributeValue("action");
+                action = actionVal == null ? null : DiscoverExternalServices.Service.Action.valueOf(actionVal);
+                expiresString = parser.getAttributeValue("expires");
+                host = ParserUtils.getRequiredAttribute(parser,"host");
+                name = parser.getAttributeValue("name");
+                password = parser.getAttributeValue("password");
+                port = ParserUtils.getIntegerAttribute(parser, "port");
+                restricted = ParserUtils.getBooleanAttribute(parser,"restricted");
+                transport = parser.getAttributeValue("transport");
+                type = ParserUtils.getRequiredAttribute(parser,"type");
+                username = parser.getAttributeValue("username");
+            }
+            else if (eventType == XmlPullParser.Event.END_ELEMENT && DiscoverExternalServices.Service.ELEMENT.equals(parser.getName()))
+            {
+                // Create a new Service and add it to the result.
+                service = new DiscoverExternalServices.Service(host, type);
+                service.setAction(action);
+                service.setExpires(expiresString);
+                service.setName(name);
+                service.setPassword(password);
+                service.setPort(port);
+                service.setRestricted(restricted);
+                service.setTransport(transport);
+                service.setUsername(username);
+
+                result.addService(service);
+            }
+            else if (eventType == XmlPullParser.Event.END_ELEMENT && DiscoverExternalServices.ELEMENT.equals(parser.getName()))
+            {
+                done = true;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/ServiceCredentialsProvider.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/ServiceCredentialsProvider.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0215.provider;
+
+import org.igniterealtime.smack.inttest.xep0215.packet.ServiceCredentials;
+import org.jivesoftware.smack.packet.IqData;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.provider.IqProvider;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+
+import java.io.IOException;
+
+/**
+ * A provider for ServiceCredentials stanzas.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="https://xmpp.org/extensions/xep-0215.html">XEP-0215: External Service Discovery</a>
+ */
+public class ServiceCredentialsProvider extends IqProvider<ServiceCredentials>
+{
+    public ServiceCredentials parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment)
+        throws XmlPullParserException, IOException
+    {
+        boolean done = false;
+        ServiceCredentials.Service service;
+        String host = null;
+        String password = null;
+        Integer port = null;
+        String type = null;
+        String username = null;
+        final ServiceCredentials result = new ServiceCredentials(host, type);
+
+        while (!done)
+        {
+            final XmlPullParser.Event eventType = parser.next();
+
+            if (eventType == XmlPullParser.Event.START_ELEMENT && ServiceCredentials.Service.ELEMENT.equals(parser.getName()))
+            {
+                // Initialize the variables from the parsed XML
+                host = ParserUtils.getRequiredAttribute(parser,"host");
+                password = parser.getAttributeValue("password");
+                port = ParserUtils.getIntegerAttribute(parser, "port");
+                type = ParserUtils.getRequiredAttribute(parser,"type");
+                username = parser.getAttributeValue("username");
+            }
+            else if (eventType == XmlPullParser.Event.END_ELEMENT && ServiceCredentials.Service.ELEMENT.equals(parser.getName()))
+            {
+                // Create a new Service and add it to the result.
+                service = new ServiceCredentials.Service(host, type);
+                service.setPassword(password);
+                service.setPort(port);
+                service.setUsername(username);
+
+                result.addService(service);
+            }
+            else if (eventType == XmlPullParser.Event.END_ELEMENT && ServiceCredentials.ELEMENT.equals(parser.getName()))
+            {
+                done = true;
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/package-info.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0215/provider/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * XMPP parsing functionality that generates stanza representations for XEP-0215: External Service Discovery
+ */
+package org.igniterealtime.smack.inttest.xep0215.provider;


### PR DESCRIPTION
Note that for Openfire, none of these tests can run (they'll be automatically skipped) unless the [External Service Discovery plugin](https://www.igniterealtime.org/projects/openfire/plugin-archive.jsp?plugin=externalservicediscovery) is loaded.

At the time of writing, that plugin contains on bug that is correctly identified by the tests that I'm adding in this PR. The ticket for that bug is here: https://github.com/igniterealtime/openfire-externalservicediscovery-plugin/issues/16