### PR TITLE
Add tests for XEP-0363 HTTP File Upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
             <artifactId>smack-legacy</artifactId>
             <version>${smack.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dmfs</groupId>
+            <artifactId>rfc3986-uri</artifactId>
+            <version>0.8.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/HttpFileUploadExtIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/HttpFileUploadExtIntegrationTest.java
@@ -1,0 +1,400 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363;
+
+import org.dmfs.rfc3986.encoding.Precoded;
+import org.dmfs.rfc3986.uris.LazyUri;
+import org.igniterealtime.smack.inttest.AbstractSmackIntegrationTest;
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.xep0363.element.RetryError;
+import org.igniterealtime.smack.inttest.xep0363.element.SlotRaw;
+import org.igniterealtime.smack.inttest.xep0363.provider.RetryErrorProvider;
+import org.igniterealtime.smack.inttest.xep0363.provider.SlotRawProvider;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.provider.IqProvider;
+import org.jivesoftware.smack.provider.ProviderManager;
+import org.jivesoftware.smack.util.ParserUtils;
+import org.jivesoftware.smack.util.StringUtils;
+import org.jivesoftware.smackx.httpfileupload.HttpFileUploadManager;
+import org.jivesoftware.smackx.httpfileupload.element.SlotRequest;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Additional tests for HTTP file Upload. This completes the integration test that's provided by Smack.
+ *
+ * @see {@link org.jivesoftware.smackx.httpfileupload.HttpFileUploadIntegrationTest}
+ */
+@SpecificationReference(document = "XEP-0363", version = "1.1.0")
+public class HttpFileUploadExtIntegrationTest extends AbstractSmackIntegrationTest
+{
+    private final HttpFileUploadManager hfumOne;
+
+    private final SSLSocketFactory tlsSocketFactory;
+
+    public HttpFileUploadExtIntegrationTest(SmackIntegrationTestEnvironment environment) throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+        hfumOne = HttpFileUploadManager.getInstanceFor(conOne);
+        if (!hfumOne.discoverUploadService()) {
+            throw new TestNotPossibleException("Unable to find any service on domain that supports XEP-0363: HTTP File Upload.");
+        }
+
+        if (environment.configuration.sslContextFactory != null) {
+            tlsSocketFactory = environment.configuration.sslContextFactory.createSslContext().getSocketFactory();
+        } else {
+            tlsSocketFactory = null;
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with [..] a GET URL wrapped by a <slot> element.")
+    public void testSlotResponseContainsGet() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertNotNull(response.getGetUrl(), "Expected the slot requested by '" + conOne + "' from '" + request.getTo() + "' to contain a GET URL (but it did not).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with [...] a PUT [...] wrapped by a <slot> element.")
+    public void testSlotResponseContainsPut() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertNotNull(response.getPutUrl(), "Expected the slot requested by '" + conOne + "' from '" + request.getTo() + "' to contain a PUT URL (but it did not).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...] The host MUST provide Transport Layer Security (RFC 5246).")
+    public void testSlotResponseGetUrlProvideTLS() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertEquals("https", response.getGetUrl().substring(0, 5), "Expected the GET URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to start with 'https' (but it did not).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...] The host MUST provide Transport Layer Security (RFC 5246).")
+    public void testSlotResponsePutUrlProvideTLS() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertEquals("https", response.getPutUrl().substring(0, 5), "Expected the PUT URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to start with 'https' (but it did not).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...] Both HTTPS URLs MUST adhere to RFC 3986")
+    public void testSlotResponseGetUrlAdhereToRFC3986() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            try {
+                new LazyUri(new Precoded(response.getGetUrl())).fragment().isPresent(); // call fragment().isPresent() to cause entire URI to be parsed.
+            } catch (RuntimeException e) {
+                fail("Expected the GET URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to parse as a RFC3986 URI (but it did not).", e);
+            }
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...] Both HTTPS URLs MUST adhere to RFC 3986")
+    public void testSlotResponsePutUrlAdhereToRFC3986() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "testfile-" + StringUtils.randomString(5) + ".txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            try {
+                new LazyUri(new Precoded(response.getPutUrl())).fragment().isPresent(); // call fragment().isPresent() to cause entire URI to be parsed.
+            } catch (RuntimeException e) {
+                fail("Expected the PUT URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to parse as a RFC3986 URI (but it did not).", e);
+            }
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...]. Non ASCII characters MUST be percent-encoded.")
+    public void testSlotResponseGetUrlIsPercentEncoded() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "très cool.txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            final String rawGetUrl = response.getGetUrl();
+            final String decodedGetUrl = URLDecoder.decode(rawGetUrl, StandardCharsets.UTF_8);
+            // Note: we can't be sure that the service used the file name from the request in the response. We can only check for the absence of characters that need to be percent-encoded.
+            assertTrue(StandardCharsets.US_ASCII.newEncoder().canEncode(rawGetUrl), "Expected the GET URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to contain only ASCII characters (but it did not).");
+            if (rawGetUrl.equals(decodedGetUrl)) {
+                throw new TestNotPossibleException("The generated GET URL did not contain percent-encoded character nor characters that needed percent-encoding.");
+            }
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "A client requests a new upload slot [...] The upload service responds with both a PUT and a GET URL [...]. Non ASCII characters MUST be percent-encoded.")
+    public void testSlotResponsePutUrlIsPercentEncoded() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "très cool.txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            final String rawPutUrl = response.getPutUrl();
+            final String decodedPutUrl = URLDecoder.decode(rawPutUrl, StandardCharsets.UTF_8);
+            // Note: we can't be sure that the service used the file name from the request in the response. We can only check for the absence of characters that need to be percent-encoded.
+            assertTrue(StandardCharsets.US_ASCII.newEncoder().canEncode(rawPutUrl), "Expected the PUT URL from the slot returned by '" + request.getTo() + "' to '" + conOne + "' to contain only ASCII characters (but it did not).");
+            if (rawPutUrl.equals(decodedPutUrl)) {
+                throw new TestNotPossibleException("The generated PUT URL did not contain percent-encoded character nor characters that needed percent-encoding.");
+            }
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "The <put> element MAY also contain a number of <header> elements [...]. Each <header> element MUST have a name-attribute [...]")
+    public void testPutHeadersHaveNameAttribute() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "très cool.txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+            final Map<String, String> headers = response.getHeaders();
+
+            // Verify result.
+            if (headers.isEmpty()) {
+                throw new TestNotPossibleException("The generated PUT URL did not contain any headers that can be tested.");
+            }
+            assertFalse(headers.containsKey(null), "Expected all of the headers in the 'put' element in the slot sent to '" + request.getTo() + "' by '" + conOne + "' to have a name-attribute (but not all had - detected a missing or 'null' name).");
+            assertFalse(headers.containsKey(""), "Expected all of the headers in the 'put' element in the slot sent to '" + request.getTo() + "' by '" + conOne + "' to have a name-attribute (but not all had - detected a missing or empty name).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "4", quote = "The <put> element MAY also contain a number of <header> elements [...]. Only the following header names are allowed: Authorization, Cookie, Expires")
+    public void testPutHeadersHaveValidNames() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        try {
+            final String data = "This is part of an integration test.";
+            final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "très cool.txt", data.getBytes().length);
+
+            // Execute system-under-test.
+            final SlotRaw response = connection.sendIqRequestAndWaitForResponse(request);
+            final Map<String, String> headers = response.getHeaders();
+
+            // Verify result.
+            if (headers.isEmpty()) {
+                throw new TestNotPossibleException("The generated PUT URL did not contain any headers that can be tested.");
+            }
+            final Set<String> validHeaderNames = Set.of("authorization", "cookie", "expires"); // Each header name MAY be present zero or more times, and are case insensitive (eXpires is the same as Expires).
+            final Set<String> offendingNames = new HashSet<>();
+            for (final String headerName : headers.keySet()) {
+                if (headerName != null && !validHeaderNames.contains(headerName.toLowerCase())) {
+                    offendingNames.add(headerName);
+                }
+            }
+            assertTrue(offendingNames.isEmpty(), "Expected all of the headers returned in the 'put' element in the slot sent to '" + request.getTo() + "' by '" + conOne + "' to have a name-attribute that (case-insensitively) matches one of [" + String.join(", ", validHeaderNames) + "] (but not all had. Invalid value(s): [" + String.join(", ", offendingNames) + "]).");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+        }
+    }
+
+    @SmackIntegrationTest(section = "5", quote = " the service MAY include a <retry/> element [...]. The retry element MUST include an attribute 'stamp' which indicates the time at which the requesting entity may try again. The format of the timestamp MUST adhere to the date-time format specified in XMPP Date and Time Profiles (XEP-0082) and MUST be expressed in UTC.")
+    public void testRetryError() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final IqProvider<IQ> oldProvider = ProviderManager.getIQProvider("slot", "urn:xmpp:http:upload:0");
+        ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", new SlotRawProvider());
+        final ExtensionElementProvider<ExtensionElement> oldExtensionProvider = ProviderManager.getExtensionProvider(RetryError.ELEMENT, RetryError.NAMESPACE);
+        ProviderManager.addExtensionProvider(RetryError.ELEMENT, RetryError.NAMESPACE, new RetryErrorProvider());
+        try {
+            // Execute system-under-test (attempt to hit a rate-limit).
+            for (int i = 0; i < 10; i++) {
+                final String data = "This is part of an integration test that attempts to hit a rate-limit. " + StringUtils.randomString(10);
+                final SlotRequest request = new SlotRequest(hfumOne.getDefaultUploadService().getAddress(), "test-ratelimit-" + StringUtils.randomString(4) + ".txt", data.getBytes().length);
+                connection.sendIqRequestAndWaitForResponse(request);
+            }
+            throw new TestNotPossibleException("The test was unable to generate an error of which this test intends to assert its properties.");
+        } catch (XMPPException.XMPPErrorException e) {
+            // Verify result.
+            final RetryError retry = e.getStanzaError().getExtension("retry", "urn:xmpp:http:upload:0");
+            if (retry != null) {
+                // Multiple assertions, that could go in seperate tests. As this test involves generating a flood of requests (trying to reach resource starvation), let's combine all the tests into one. This reduces overhead.
+                assertNotNull(retry.getStamp(), "The 'retry' element included in the error returned by " + hfumOne.getDefaultUploadService().getAddress() + "' to '" + conOne + "' was expected to contain a 'stamp' attribute value (but it did not).");
+                try {
+                    ParserUtils.getDateFromXep82String(retry.getStamp());
+                } catch (ParseException pe) {
+                    fail("Expected the 'stamp' attribute value of the 'retry' element included in the error returned by " + hfumOne.getDefaultUploadService().getAddress() + "' to '" + conOne + "' to be in the dateTime format specified in XMPP Date and Time Profiles (XEP-0082), but it was not. Offending value: " + retry.getStamp(), pe);
+                }
+                final String[] zuluEndings = new String[] { "z", "Z", "+00:00", "-00:00"};
+                assertTrue(Arrays.stream(zuluEndings).anyMatch(retry.getStamp()::endsWith), "Expected the 'stamp' attribute value of the 'retry' element included in the error returned by " + hfumOne.getDefaultUploadService().getAddress() + "' to '" + conOne + "' to be expressed in UTC, but it was not. Offending value: " + retry.getStamp());
+                return; // Done asserting. Do not process anything else.
+            }
+            // This test intentionally floods the service. This might result in an exception that is not explicitly the subject of the assertions of this text, but not unexpected either. Do not rethrow.
+            throw new TestNotPossibleException("The error returned by the service did not contain an attribute that can be checked by this test.");
+        } finally {
+            // Restore the previous provider, if there was one.
+            ProviderManager.removeIQProvider("slot", "urn:xmpp:http:upload:0");
+            if (oldProvider != null) {
+                ProviderManager.addIQProvider("slot", "urn:xmpp:http:upload:0", oldProvider);
+            }
+            ProviderManager.removeExtensionProvider(RetryError.ELEMENT, RetryError.NAMESPACE);
+            if (oldExtensionProvider != null) {
+                ProviderManager.addExtensionProvider(RetryError.ELEMENT, RetryError.NAMESPACE, oldExtensionProvider);
+            }
+        }
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/RetryError.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/RetryError.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363.element;
+
+import org.jivesoftware.smack.packet.XmlElement;
+import org.jivesoftware.smack.util.XmlStringBuilder;
+
+/**
+ * A representation of a 'retry' error element, as specified in XEP-0363.
+ *
+ * This implementation deliberately does not attempt to validate the provided timestamp, as such validation is subject
+ * of a test implementation that depends on this class.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ */
+public class RetryError implements XmlElement
+{
+    public static String ELEMENT = "retry";
+    public static String NAMESPACE = "urn:xmpp:http:upload:0";
+
+    private final String stamp; // Do not use a more specific type, as the integration test wants to use the raw value.
+
+    public RetryError(final String stamp)
+    {
+        this.stamp = stamp;
+    }
+
+    public String getStamp() {
+        return stamp;
+    }
+
+    @Override
+    public String getNamespace()
+    {
+        return NAMESPACE;
+    }
+
+    @Override
+    public String getElementName()
+    {
+        return ELEMENT;
+    }
+
+    @Override
+    public XmlStringBuilder toXML(org.jivesoftware.smack.packet.XmlEnvironment enclosingNamespace) {
+        XmlStringBuilder xml = new XmlStringBuilder(this);
+        xml.attribute("stamp", stamp);
+        xml.closeEmptyElement();
+        return xml;
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/SlotRaw.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/SlotRaw.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363.element;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smackx.httpfileupload.element.SlotRequest;
+
+/**
+ * A duplicate of Smack's Slot implementation, but one that stores the URLs as raw strings.
+ *
+ * Note that in most cases, it is preferable to use {@link org.jivesoftware.smackx.httpfileupload.element.Slot} instead
+ * of this class. It is functionally equivalent, but provides better type-safety.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ * @see org.jivesoftware.smackx.httpfileupload.element.Slot
+ */
+public class SlotRaw extends IQ {
+
+    public static final String ELEMENT = "slot";
+    public static final String NAMESPACE = SlotRequest.NAMESPACE;
+
+    protected final String putUrl;
+    protected final String getUrl;
+
+    private final Map<String, String> headers;
+
+    public SlotRaw(String putUrl, String getUrl) {
+        this(putUrl, getUrl, null);
+    }
+
+    public SlotRaw(String putUrl, String getUrl, Map<String, String> headers) {
+        this(putUrl, getUrl, headers, NAMESPACE);
+    }
+
+    protected SlotRaw(String putUrl, String getUrl, Map<String, String> headers, String namespace) {
+        super(ELEMENT, namespace);
+        setType(Type.result);
+        this.putUrl = putUrl;
+        this.getUrl = getUrl;
+        if (headers == null) {
+            this.headers = Collections.emptyMap();
+        } else {
+            this.headers = Collections.unmodifiableMap(headers);
+        }
+    }
+
+    public String getPutUrl() {
+        return putUrl;
+    }
+
+    public String getGetUrl() {
+        return getUrl;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    protected IQChildElementXmlStringBuilder getIQChildElementBuilder(IQChildElementXmlStringBuilder xml) {
+        xml.rightAngleBracket();
+
+        xml.halfOpenElement("put").attribute("url", putUrl);
+        if (headers.isEmpty()) {
+            xml.closeEmptyElement();
+        } else {
+            xml.rightAngleBracket();
+            for (Map.Entry<String, String> entry : getHeaders().entrySet()) {
+                xml.halfOpenElement("header").attribute("name", entry.getKey()).rightAngleBracket();
+                xml.escape(entry.getValue());
+                xml.closeElement("header");
+            }
+            xml.closeElement("put");
+        }
+
+        xml.halfOpenElement("get").attribute("url", getUrl).closeEmptyElement();
+
+        return xml;
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/SlotRaw_V0_2.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/element/SlotRaw_V0_2.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363.element;
+
+import org.jivesoftware.smack.packet.IQ;
+
+import java.util.Map;
+
+/**
+ * A duplicate of Smack's Slot_V0_2 implementation, but one that stores the URLs as raw strings.
+ *
+ * Note that in most cases, it is preferable to use {@link org.jivesoftware.smackx.httpfileupload.element.Slot_V0_2} instead
+ * of this class. It is functionally equivalent, but provides better type-safety.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ * @see org.jivesoftware.smackx.httpfileupload.element.Slot_V0_2
+ */
+public class SlotRaw_V0_2 extends SlotRaw {
+    public static final String NAMESPACE = "urn:xmpp:http:upload";
+
+    public SlotRaw_V0_2(String putUrl, String getUrl) {
+        super(putUrl, getUrl, (Map)null, "urn:xmpp:http:upload");
+    }
+
+    protected IQ.IQChildElementXmlStringBuilder getIQChildElementBuilder(IQ.IQChildElementXmlStringBuilder xml) {
+        xml.rightAngleBracket();
+        xml.element("put", this.putUrl);
+        xml.element("get", this.getUrl);
+        return xml;
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/package-info.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Integration Tests for the XEP-0363: HTTP File Upload
+ */
+package org.igniterealtime.smack.inttest.xep0363;

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/provider/RetryErrorProvider.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/provider/RetryErrorProvider.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363.provider;
+
+import org.igniterealtime.smack.inttest.xep0363.element.RetryError;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.provider.ExtensionElementProvider;
+import org.jivesoftware.smack.xml.XmlPullParser;
+
+/**
+ * A provider of HTTP File Upload 'retry' error elements.
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ */
+public class RetryErrorProvider extends ExtensionElementProvider<RetryError>
+{
+    @Override
+    public RetryError parse(XmlPullParser parser, int initialDepth, XmlEnvironment xmlEnvironment) {
+        String stamp = parser.getAttributeValue("stamp");
+        return new RetryError(stamp);
+    }
+}

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0363/provider/SlotRawProvider.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0363/provider/SlotRawProvider.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.xep0363.provider;
+
+import org.igniterealtime.smack.inttest.xep0363.element.SlotRaw;
+import org.igniterealtime.smack.inttest.xep0363.element.SlotRaw_V0_2;
+import org.jivesoftware.smack.packet.IqData;
+import org.jivesoftware.smack.packet.XmlEnvironment;
+import org.jivesoftware.smack.provider.IqProvider;
+import org.jivesoftware.smack.xml.XmlPullParser;
+import org.jivesoftware.smack.xml.XmlPullParserException;
+import org.jivesoftware.smackx.httpfileupload.HttpFileUploadManager;
+import org.jivesoftware.smackx.httpfileupload.UploadService;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A duplicate of Smack's SlotProvider implementation, but one that generates instances of
+ * {@link org.igniterealtime.smack.inttest.xep0363.element.SlotRaw}
+ *
+ * @author Guus der Kinderen, guus@goodbytes.nl
+ * @see <a href="http://xmpp.org/extensions/xep-0363.html">XEP-0363: HTTP File Upload</a>
+ * @see org.igniterealtime.smack.inttest.xep0363.element.SlotRaw
+ */
+public class SlotRawProvider extends IqProvider<SlotRaw> {
+
+    @Override
+    public SlotRaw parse(XmlPullParser parser, int initialDepth, IqData iqData, XmlEnvironment xmlEnvironment) throws XmlPullParserException, IOException {
+        final String namespace = parser.getNamespace();
+
+        final UploadService.Version version = HttpFileUploadManager.namespaceToVersion(namespace);
+        assert version != null;
+
+        String putUrl = null;
+        String getUrl = null;
+        PutElement_V0_4_Content putElementV04Content = null;
+
+        outerloop: while (true) {
+            XmlPullParser.Event event = parser.next();
+
+            switch (event) {
+                case START_ELEMENT:
+                    String name = parser.getName();
+                    switch (name) {
+                        case "put": {
+                            switch (version) {
+                            case v0_2:
+                                putUrl = parser.nextText();
+                                break;
+                            case v0_3:
+                                putElementV04Content = parsePutElement_V0_4(parser);
+                                break;
+                            default:
+                                throw new AssertionError();
+                            }
+                            break;
+                        }
+                        case "get":
+                            switch (version) {
+                            case v0_2:
+                                getUrl = parser.nextText();
+                                break;
+                            case v0_3:
+                                getUrl = parser.getAttributeValue(null, "url");
+                                break;
+                            default:
+                                throw new AssertionError();
+                            }
+                            break;
+                    }
+                    break;
+                case END_ELEMENT:
+                    if (parser.getDepth() == initialDepth) {
+                        break outerloop;
+                    }
+                    break;
+                default:
+                    // Catch all for incomplete switch (MissingCasesInEnumSwitch) statement.
+                    break;
+            }
+        }
+
+        switch (version) {
+        case v0_3:
+            return new SlotRaw(putElementV04Content.putUrl, getUrl, putElementV04Content.headers);
+        case v0_2:
+            return new SlotRaw_V0_2(putUrl, getUrl);
+        default:
+            throw new AssertionError();
+        }
+    }
+
+    public static PutElement_V0_4_Content parsePutElement_V0_4(XmlPullParser parser) throws XmlPullParserException, IOException {
+        final int initialDepth = parser.getDepth();
+
+        String putUrl = parser.getAttributeValue(null, "url");
+
+        Map<String, String> headers = null;
+        outerloop: while (true) {
+            XmlPullParser.Event next = parser.next();
+            switch (next) {
+            case START_ELEMENT:
+                String name = parser.getName();
+                switch (name) {
+                case "header":
+                    String headerName = parser.getAttributeValue("name");
+                    String headerValue = parser.nextText();;
+                    if (headers == null) {
+                        headers = new HashMap<>();
+                    }
+                    headers.put(headerName, headerValue);
+                    break;
+                default:
+                    break;
+                }
+                break;
+            case END_ELEMENT:
+                if (parser.getDepth() == initialDepth) {
+                    break outerloop;
+                }
+                break;
+            default:
+                // Catch all for incomplete switch (MissingCasesInEnumSwitch) statement.
+                break;
+            }
+        }
+
+        return new PutElement_V0_4_Content(putUrl, headers);
+    }
+
+    public static final class PutElement_V0_4_Content {
+        private final String putUrl;
+        private final Map<String, String> headers;
+
+        private PutElement_V0_4_Content(String putUrl, Map<String, String> headers) {
+            this.putUrl = putUrl;
+            this.headers = headers;
+        }
+
+        public String getPutUrl() {
+            return putUrl;
+        }
+
+        public Map<String, String> getHeaders() {
+            return headers;
+        }
+    }
+}


### PR DESCRIPTION
Note that in Openfire, unless the appropriate plugin is installed, these tests will be skipped.