### PR TITLE
CI: Add Java 21 to list JDKs used for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 17, 21 ]
         distribution: [ temurin ] # We could add more here: temurin, adopt, liberica, microsoft, corretto
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Java 21 is a LTS release. Let's use that in our CI too.