### PR TITLE
Enforce no presence subscription before testing presence pubsub model

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/xep0115/EntityCapabilitiesOptimizationIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0115/EntityCapabilitiesOptimizationIntegrationTest.java
@@ -90,6 +90,7 @@ public class EntityCapabilitiesOptimizationIntegrationTest extends AbstractSmack
         } finally {
             // Tear down test fixture.
             rosterOne.removePresenceEventListener(presenceEventListener);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 
@@ -143,6 +144,7 @@ public class EntityCapabilitiesOptimizationIntegrationTest extends AbstractSmack
             assertNotSame(originalVer, caps.getVer(), "Expected the 'ver' as received by '" + conOne.getUser() + "' after '" + conTwo.getUser() + "' updated its 'ver' value to be different from the value that was received previously (but it was not).");
         } finally {
             rosterOne.removePresenceEventListener(presenceEventListenerSecond);
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         }
     }
 }

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0352/CsiIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0352/CsiIntegrationTest.java
@@ -78,8 +78,16 @@ public class CsiIntegrationTest extends AbstractSmackIntegrationTest
     @SmackIntegrationTest(section = "6", quote = "To protect the privacy of users, servers MUST NOT reveal the clients active/inactive state to other entities on the network.")
     public void detectDiscoInfoChangeTestSubscribed() throws Exception
     {
-        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
-        detectDiscoInfoChangeTest();
+        try {
+            // Setup test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+
+            // Execute system under test & assert results.
+            detectDiscoInfoChangeTest();
+        } finally {
+            // Tear down test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 
     protected void detectDiscoInfoChangeTest() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException
@@ -118,8 +126,16 @@ public class CsiIntegrationTest extends AbstractSmackIntegrationTest
     @SmackIntegrationTest(section = "6", quote = "To protect the privacy of users, servers MUST NOT reveal the clients active/inactive state to other entities on the network.")
     public void detectDiscoItemsChangeTestSubscribed() throws Exception
     {
-        IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
-        detectDiscoItemsChangeTest();
+        try {
+            // Setup test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreSubscribedToEachOther(conOne, conTwo, timeout);
+
+            // Execute system under test & assert results.
+            detectDiscoItemsChangeTest();
+        } finally {
+            // Tear down test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 
     protected void detectDiscoItemsChangeTest() throws XMPPException.XMPPErrorException, SmackException.NotConnectedException, SmackException.NoResponseException, InterruptedException, TestNotPossibleException

--- a/src/main/java/org/jivesoftware/smackx/pubsub/PubSubExtIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/pubsub/PubSubExtIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.IntegrationTestRosterUtil;
 import org.jivesoftware.smack.SmackConfiguration;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.SmackException.NoResponseException;
@@ -181,11 +182,12 @@ public class PubSubExtIntegrationTest extends AbstractSmackIntegrationTest {
     @SmackIntegrationTest(section = "6.1.3.2", quote =
         "For nodes with an access model of \"presence\", if the requesting entity is not subscribed to the owner's " +
         "presence then the pubsub service MUST respond with a <not-authorized/> error (...)")
-    public void subscribePresenceSubscriptionRequiredTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException, PubSubException.NotAPubSubNodeException, TestNotPossibleException {
+    public void subscribePresenceSubscriptionRequiredTest() throws NoResponseException, XMPPErrorException, NotConnectedException, InterruptedException, PubSubException.NotAPubSubNodeException, TestNotPossibleException, SmackException.NotLoggedInException {
         final String nodeName = "sinttest-subscribe-nodename-" + testRunId;
         final ConfigureForm defaultConfiguration = pubSubManagerOne.getDefaultConfiguration();
         final FillableConfigureForm config = defaultConfiguration.getFillableForm();
         config.setAccessModel(AccessModel.presence);
+        IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
         try {
             pubSubManagerOne.createNode(nodeName, config);
         } catch (XMPPErrorException e) {


### PR DESCRIPTION
This test is failing in Circle CI but not locally. I believe this to be a test ordering difference, and that a test that runs before this is subscribing conTwo to conOne, breaking the test.

I looked at tearing down the subscription in SubscriptionIntegrationTest, but this might not be where it's occuring, and this feels more explicit.