### PR TITLE
Adds tests for XEP-0045 Multi-User Chat (section 9)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build & Test
 on: [pull_request]
 
 env:
-  OPENFIRE_VERSION: 4_8_2 # The version of Openfire to use, using underscores, to match artifact filenames in https://github.com/igniterealtime/Openfire/releases/
+  OPENFIRE_VERSION: 4_8_3 # The version of Openfire to use, using underscores, to match artifact filenames in https://github.com/igniterealtime/Openfire/releases/
 
 permissions:
   checks: write

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -1,0 +1,619 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.xdata.FormField;
+import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.Form;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.1 Admin Use Cases: Banning a User" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#ban">XEP-0045 Section 9.1</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminBanIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that a bare JID (not related to a current occupant) can be banned by an admin without providing the
+     * optional 'reason' attribute of a ban request.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The <reason/> element is OPTIONAL.")
+    public void testBanNonOccupantWithoutOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-nonoccupant-without-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByAdmin.banUser(targetAddress, null);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (that was not an occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) can be banned by an admin without providing the optional 'reason'
+     * attribute of a ban request.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The <reason/> element is OPTIONAL.")
+    public void testBanOccupantWithoutOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-occupant-without-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByAdmin.banUser(targetAddress, null);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (not related to a current occupant) can be banned by an admin when providing the
+     * optional 'reason' attribute of a ban request.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The <reason/> element is OPTIONAL.")
+    public void testBanNonOccupantWithOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-nonoccupant-with-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (that was not an occupant) from '" + mucAddress + "' while providing the optional 'reason' attribute (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) can be banned by an admin when providing the optional 'reason' 
+     * attribute of a ban request.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The <reason/> element is OPTIONAL.")
+    public void testBanOccupantWithOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-occupant-with-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' while providing the optional 'reason' attribute (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot ban someone.
+     */
+    @SmackIntegrationTest(section = "9", quote = "ban a user from the room [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToBan() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByParticipant.banUser(targetAddress, "Banned as part of a test.");
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to ban another participant ('" + targetAddress + "') from room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to ban another participant ('" + targetAddress + "') from room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (not related to a current occupant) that is banned by an admin appears on the Ban List.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The ban MUST be performed based on the occupant's bare JID. [...] The service MUST add that bare JID to the ban list [...]")
+    public void testBanNonOccupantJidOnBanList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-nonoccupant-banned-jid-on-banlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (that was not an occupant) to be on the Ban List after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) that is banned by an admin appears on the Ban List.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The ban MUST be performed based on the occupant's bare JID. [...] The service MUST add that bare JID to the ban list [...]")
+    public void testBanOccupantJidOnBanList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-occupant-banned-jid-on-banlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (an existing occupant) to be on the Ban List after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID that is banned by an admin gets its nickname removed from the list of registered nicknames.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The ban MUST be performed based on the occupant's bare JID. [...] The service [...] MUST remove the outcast's nickname from the list of registered nicknames [...]")
+    public void testBanOccupantRemovesRegisteredNickname() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-removes-registered-nickname");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+
+            try {
+                final Form registrationForm = mucAsSeenByTarget.getRegistrationForm();
+                final Set<String> requiredFieldNames = registrationForm.getDataForm().getFields()
+                    .stream().filter(FormField::isRequired).map(FormField::getFieldName).collect(Collectors.toSet());
+                final FillableForm submitForm = registrationForm.getFillableForm();
+                for (final String requiredFieldName : requiredFieldNames) {
+                    submitForm.setAnswer(requiredFieldName, "test");
+                }
+
+                if (submitForm.hasField("username")) {
+                    submitForm.setAnswer("username", nicknameTarget);
+                } else if (submitForm.hasField("muc#register_roomnick")) {
+                    submitForm.setAnswer("muc#register_roomnick", nicknameTarget);
+                } else {
+                    throw new TestNotPossibleException("Unable to register with the room (cannot identify the appropriate field for registering a nickname).");
+                }
+                mucAsSeenByTarget.sendRegistrationForm(submitForm);
+            } catch (Throwable e) {
+                throw new TestNotPossibleException("Unable to register with the room.");
+            }
+
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget + "') of '" + targetAddress + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an occupant that is banned is removed from the room.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The service MUST also remove any banned users who are in the room by sending a presence stanza of type \"unavailable\" to each banned occupant, including status code 301 in the extended presence information [...]")
+    public void testBannedOccupantReceivesRemoval() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-notification");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesBan = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void banned(Jid actor, String reason) { // Invoked only when presence with 301 is received.
+                    targetSeesBan.signal();
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+            // Verify result.
+            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when an occupant is banned.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type \"unavailable\" from the banned user to all remaining occupants [...]")
+    public void mucTestRemainingOccupantsInformedOfBan() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesBan = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesBan = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void banned(EntityFullJid participant, Jid actor, String reason) { // Invoked when presence with 301 is received.
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesBan.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void banned(EntityFullJid participant, Jid actor, String reason) { // Invoked when presence with 301 is received.
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesBan.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+
+            // Verify result.
+            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin cannot ban itself.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "If an admin [..] attempts to ban himself, the service MUST deny the request and return a <conflict/> error to the sender.")
+    public void mucTestAdminCannotBanSelf() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-cannot-ban-self");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conTwo.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is an admin) tried to ban itself from room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is an admin) after it tried to ban itself from room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin cannot ban an owner.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "[A] user cannot be banned by an admin with a lower affiliation. Therefore, if an admin attempts to ban an owner, the service MUST deny the request and return a <not-allowed/> error to the sender")
+    public void mucTestAdminCannotBanOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-cannot-ban-owner");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conOne.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is an admin) tried to ban an owner ('" + targetAddress + "') from room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is an admin) after it tried to ban an owner ('" + targetAddress + "') from room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an owner cannot ban itself.
+     */
+    @SmackIntegrationTest(section = "9.1", quote = "If an [..] owner attempts to ban himself, the service MUST deny the request and return a <conflict/> error to the sender.")
+    public void mucTestOwnerCannotBanSelf() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-cannot-ban-self");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conOne.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByOwner.banUser(targetAddress, "Banned as part of a test.");
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is an owner) tried to ban itself from room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is an owner) after it tried to ban itself from room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -31,6 +31,7 @@ import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,8 +47,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -34,6 +34,7 @@ import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.List;
 import java.util.Set;
@@ -50,8 +51,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanListIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -1,0 +1,591 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jivesoftware.smackx.xdata.FormField;
+import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.Form;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.2 Admin Use Cases: Modifying the Ban List" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyban">XEP-0045 Section 9.2</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminBanListIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Asserts that a ban list can be obtained.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.")
+    public void mucTestAdminRequestsBanList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-banlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.outcast));
+            conTwo.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+        } catch (XMPPException.XMPPErrorException e) {
+            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).", e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+
+    /**
+     * Asserts that a ban list is always based on a bare JID.
+     *
+     * This test attempts to add a full JID to the ban list (which may/should not be possible, in which case the test
+     * stops as 'not possible'), and then retrieves the ban list, asserting that the entry on it either doesn't exist,
+     * or is a bare jid.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The ban list is always based on a user's bare JID.")
+    public void mucTestAdminBanListFullJid() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-fulljid");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityFullJid targetAddress = JidCreate.entityFullFrom("test@example.org/foobar");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            try {
+                mucAsSeenByAdmin.banUser(targetAddress, "Attempt to create a ban list with a full JID (which shouldn't be possible).");
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to create a ban list using a full JID.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.outcast));
+
+            final MUCAdmin response;
+            try {
+                response = conTwo.sendIqRequestAndWaitForResponse(iq);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid().isEntityFullJid()), "The ban list for '" + mucAddress + "' unexpectedly contained an item with a full JID (where only bare JIDs are allowed).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a ban list item has 'affiliation' and 'jid' attributes.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    public void mucTestAdminBanListItemCheck() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-attr");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("test@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.banUser(targetAddress, null);
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.outcast));
+
+            final MUCAdmin response;
+            try {
+                response = conTwo.sendIqRequestAndWaitForResponse(iq);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The ban list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The ban list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the ban list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include the recently added outcast '" + targetAddress + "' (but it did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a ban list modification can contain more than one item.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items [...] back to the service; After updating the ban list, the service MUST inform the admin of success.")
+    public void mucTestAdminBanListMultipleItems() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.outcast, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.outcast, targetAddress2));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot modify the ban list.
+     */
+    @SmackIntegrationTest(section = "9", quote = "modify the list of users who are banned from the room [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToModifyBanList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.net");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByParticipant.banUsers(List.of(targetAddress1, targetAddress2));
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to modify the ban list of room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to modify the ban list of room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a ban list modification can be used to remove people from the banlist.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. [...] each item MUST include the 'affiliation' attribute (normally set to a value of \"outcast\" to ban or \"none\" to remove ban)")
+    public void mucTestAdminBanListMultipleItemsUnban() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
+
+            // Execute system under test
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress2));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (but does appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (but does appear on the ban list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a ban list modification can contain more than one item, that have optional attributes set.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items [...] back to the service; After updating the ban list, the service MUST inform the admin of success.")
+    public void mucTestAdminBanListMultipleItemsWithOptionalAttributes() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple-opt");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.outcast, null, conTwo.getUser().asBareJid(), "Testing optional reason A for banning", targetAddress1, null, nicknameAdmin));
+            iq.addItem(new MUCItem(MUCAffiliation.outcast, null, conTwo.getUser().asBareJid(), "Testing optional reason B for banning", targetAddress2, null, nicknameAdmin));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a ban list modification is a delta: it shouldn't affect entries already on the ban list that are
+     * not included in the delta.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\") [...]")
+    public void mucTestAdminBanListIsDelta() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-delta");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+        final EntityBareJid targetAddress3 = JidCreate.entityBareFrom("test3@example.net");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.outcast, targetAddress3));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+
+            final Set<Jid> outcasts = mucAsSeenByAdmin.getOutcasts().stream().filter(i -> i.getAffiliation().equals(MUCAffiliation.outcast)).map(Affiliate::getJid).collect(Collectors.toSet());
+            assertFalse(outcasts.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the ban list of '" + mucAddress + "', after '" + conTwo.getUser() + "' updated the ban list that previously contained them with their removal (but does still appear on the ban list).");
+            assertTrue(outcasts.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously contained them got updated by '" + conTwo.getUser() + "' with different items (which should have been applied as a delta).");
+            assertTrue(outcasts.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously did not contain them got updated by '" + conTwo.getUser() + "' with items that include them.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants that are banned by modification of the banlist are removed from the room.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST then remove the affected occupants (if they are in the room)")
+    public void mucTestBanListOccupantsInformedOfBan() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-notification");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesBan = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void banned(Jid actor, String reason) { // Invoked only when presence with 301 is received.
+                    targetSeesBan.signal();
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when banlist changes are made.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST then remove the affected occupants [...] and send updated presence (including the appropriate status code) from them to all the remaining occupants")
+    public void mucTestBanListRemainingOccupantsInformedOfBan() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesBan = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesBan = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void banned(EntityFullJid participant, Jid actor, String reason) { // Invoked when presence with 301 is received.
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesBan.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void banned(EntityFullJid participant, Jid actor, String reason) { // Invoked when presence with 301 is received.
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesBan.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that entities banned from a room through ban list modifications get their nickname removed from the list
+     * of registered nicknames.
+     */
+    @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.")
+    public void mucTestBanListRemovesRegisteredNickname() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-removes-registered-nickname");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+
+            try {
+                final Form registrationForm = mucAsSeenByTarget1.getRegistrationForm();
+                final Set<String> requiredFieldNames = registrationForm.getDataForm().getFields()
+                    .stream().filter(FormField::isRequired).map(FormField::getFieldName).collect(Collectors.toSet());
+                final FillableForm submitForm = registrationForm.getFillableForm();
+                for (final String requiredFieldName : requiredFieldNames) {
+                    submitForm.setAnswer(requiredFieldName, "test");
+                }
+
+                if (submitForm.hasField("username")) {
+                    submitForm.setAnswer("username", nicknameTarget1);
+                } else if (submitForm.hasField("muc#register_roomnick")) {
+                    submitForm.setAnswer("muc#register_roomnick", nicknameTarget1);
+                } else {
+                    throw new TestNotPossibleException("Unable to register with the room (cannot identify the appropriate field for registering a nickname).");
+                }
+                mucAsSeenByTarget1.sendRegistrationForm(submitForm);
+
+                // FIXME: Find a way to get 'target2' registered as a member.
+            } catch (Throwable e) {
+                throw new TestNotPossibleException("Unable to register with the room.");
+            }
+
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget1.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget1 + "') of '" + targetAddress1 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget2.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget2 + "') of '" + targetAddress2 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO Determine if tests are needed that verify behavior when through banlist modifications, an admin tries to ban an owner, or when an admin or owner bans themselves.
+    //      This seems to be undesirable, but isn't specifically mentioned in section 9.2. This also raises the question on what to do when a banlist modification consists
+    //      of 'valid' and 'invalid' modifications. Should those all be rejected, or should only the valid ones be applied?
+    //      Question asked on https://mail.jabber.org/hyperkitty/list/standards@xmpp.org/thread/UJSUVFKHN6LXR33ZIY34SYFQHNRVEB7R/
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -30,6 +30,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,8 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantMemberIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -1,0 +1,326 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.3 Admin Use Cases: Granting Membership" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmember">XEP-0045 Section 9.3</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminGrantMemberIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that an admin can grant membership to a user.
+     */
+    @SmackIntegrationTest(section = "9.3", quote = "An admin can grant membership to a user; this is done by changing the affiliation for the user's bare JID to \"member\"")
+    public void testGrantMembership() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("target-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.member, targetAddress));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin can grant membership to a user while providing an optional nick.
+     */
+    @SmackIntegrationTest(section = "9.3", quote = "An admin can grant membership to a user; this is done by changing the affiliation for the user's bare JID to \"member\" (if a nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation).")
+    public void testGrantMembershipWithNick() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-nick");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("member-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.member, null, null, null, targetAddress, nicknameTarget, null));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin can grant membership to a user while providing an optional reason.
+     */
+    @SmackIntegrationTest(section = "9.3", quote = "An admin can grant membership to a user; [...] The <reason/> element is OPTIONAL.")
+    public void testGrantMembershipWithReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.member, null, null, "Granted membership as part of a test.", targetAddress, null, null));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot grant someone membership.
+     */
+    @SmackIntegrationTest(section = "9", quote = "grant [...] membership [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToGrantMembership() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.member, targetAddress));
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to grant membership to another participant ('" + targetAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant membership to another participant ('" + targetAddress + "') for room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) that is granted membership by an admin appears on the Member List.
+     */
+    @SmackIntegrationTest(section = "9.3", quote = "An admin can grant membership to a user; [...] The service MUST add the user to the member list [...] ")
+    public void testMemberOnMemberList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-on-memberlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.member, targetAddress));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress + "' to be on the Member List after the were granted membership by '" + conTwo + "' to '" + mucAddress + "' (but the JID does not appear on the Member List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant is granted membership.
+     */
+    @SmackIntegrationTest(section = "9.3", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\".")
+    public void mucTestOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesMembership = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesMembership = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesMembership = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener()
+            {
+                @Override
+                public void membershipGranted()
+                {
+                    targetSeesMembership.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesMembership.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesMembership.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            try {
+                mucAsSeenByAdmin.grantMembership(targetAddress);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertResult(targetSeesMembership, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after they are granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesMembership, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesMembership, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.6 Admin Use Cases: Granting Moderator Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmod">XEP-0045 Section 9.6</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminGrantModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that an admin can grant moderator status to a user.
+     */
+    @SmackIntegrationTest(section = "9.6", quote = "An admin might want to grant moderator status to a participant or visitor; this is done by changing the user's role to \"moderator\"")
+    public void testGrantModerator() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-grant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.moderator, nicknameTarget));
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin can grant moderator status to a user.
+     */
+    @SmackIntegrationTest(section = "9.6", quote = "An admin might want to grant moderator status to a participant or visitor; this is done by changing the user's role to \"moderator\" [...] The <reason/> element is OPTIONAL.")
+    public void testGrantModeratorOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-grant-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.moderator, nicknameTarget, "Granting Moderator Status as part of an integration test."));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' when providing an optional 'reason' element (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot grant someone moderator status.
+     */
+    @SmackIntegrationTest(section = "9", quote = "grant [...] moderator status [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToGrantModeratorStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            participantSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.moderator, nicknameTarget, "Granting Moderator Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to grant moderator status to another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant moderator status to another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) that is granted moderator status by an admin appears on the Moderator List.
+     */
+    @SmackIntegrationTest(section = "9.6", quote = "An admin might want to grant moderator status to a participant or visitor; [...] The service MUST add the user to the moderator list  [...] ")
+    public void testModeratorOnModeratorList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-on-moderatorlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.moderator, nicknameTarget));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertTrue(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to be on the Moderator List after the were granted moderator status by '" + conTwo + "' in '" + mucAddress + "' (but the nickname does not appear on the Moderator List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant is granted moderator status.
+     */
+    @SmackIntegrationTest(section = "9.6", quote = "The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'role' attribute set to a value of \"moderator\".")
+    public void mucTestOccupantsInformed() throws Exception {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesModerator = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesModerator = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesModerator = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener()
+            {
+                @Override
+                public void moderatorGranted()
+                {
+                    targetSeesModerator.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesModerator.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesModerator.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.moderator, nicknameTarget));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertResult(targetSeesModerator, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after they are granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesModerator, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesModerator, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -30,6 +30,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -42,8 +43,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -34,6 +34,7 @@ import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.Jid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.List;
 import java.util.Set;
@@ -50,8 +51,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminMemberListIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -1,0 +1,532 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.filter.*;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Presence;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jivesoftware.smackx.muc.packet.MUCUser;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.Jid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.5 Admin Use Cases: Modifying the Member List" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymember">XEP-0045 Section 9.5</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminMemberListIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Asserts that a member list can be obtained.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "The admin [...] requests the member list by querying the room for all users with an affiliation of \"member\"")
+    public void mucTestAdminRequestsMemberList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-memberlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.member));
+            conTwo.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+        } catch (XMPPException.XMPPErrorException e) {
+            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the member list from '" + mucAddress + "' (but the server returned an error).", e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member list item has 'affiliation' and 'jid' attributes.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    public void mucTestAdminMemberListItemCheck() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-attr");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("test@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantMembership(targetAddress);
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.member));
+            final MUCAdmin response = conTwo.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The member list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The member list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the member list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include the recently added member '" + targetAddress + "' (but it did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member list modification can contain more than one item.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. In order to do so, the admin MUST send the changed items [...] to the service; [...] The service MUST modify the member list and then inform the moderator of success:")
+    public void mucTestAdminMemberListMultipleItems() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.member, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.member, targetAddress2));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the member list by '" + conTwo.getUser() + "' (but does not appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the member list by '" + conTwo.getUser() + "' (but does not appear on the member list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member list modification can be used to remove people from the member list.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. [...] each item MUST include the 'affiliation' attribute (normally set to a value of \"member\" or \"none\")")
+    public void mucTestAdminMemberListMultipleItemsRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            mucAsSeenByAdmin.grantMembership(List.of(targetAddress1, targetAddress2));
+
+            // Execute system under test
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress2));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (but does appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (but does appear on the member list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member list modification is a delta: it shouldn't affect entries already on the member list that are
+     * not included in the delta.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\")")
+    public void mucTestAdminMemberListIsDelta() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-delta");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+        final EntityBareJid targetAddress3 = JidCreate.entityBareFrom("test3@example.net");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.grantMembership(List.of(targetAddress1, targetAddress2));
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, targetAddress1));
+            iq.addItem(new MUCItem(MUCAffiliation.member, targetAddress3));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(iq);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).");
+            }
+
+            // Verify result.
+            final Set<Jid> members = mucAsSeenByAdmin.getMembers().stream().filter(i -> i.getAffiliation().equals(MUCAffiliation.member)).map(Affiliate::getJid).collect(Collectors.toSet());
+            assertFalse(members.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the member list of '" + mucAddress + "', after '" + conTwo.getUser() + "' updated the member list that previously contained them with their removal (but does still appear on the member list).");
+            assertTrue(members.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the member list of '" + mucAddress + "', after the member list that previously contained them got updated by '" + conTwo.getUser() + "' with different items (which should have been applied as a delta).");
+            assertTrue(members.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the member list of '" + mucAddress + "', after the member list that previously did not contain them got updated by '" + conTwo.getUser() + "' with items that include them.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants that get their membership revoked by modification of the member list are prevented
+     * from accessing the room
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "If a removed member is currently in a members-only room [..] The service MUST subsequently refuse entry to the user.")
+    public void mucTestMemberListNoEntryAfterRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-noentry");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantMembership(targetAddress);
+
+            // Execute system under test.
+            mucAsSeenByOwner.revokeMembership(targetAddress);
+
+            // Verify result.
+            assertThrows(XMPPException.XMPPErrorException.class, () -> mucAsSeenByTarget.join(nicknameTarget), "Expected '" + conThree.getUser() + "' to receive an error when trying to join room '" + mucAddress + "' after '" + conOne.getUser() + "' removed them from the member list (but no error was received).'");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when member list changes are made.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "[for a removed member] For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\".")
+    public void mucTestMemberListRemainingOccupantsInformedOfRevokeOpenRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-revoke-open");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByOwner.grantMembership(List.of(targetAddress1, targetAddress2));
+
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesRevoke.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.revokeMembership(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when member list changes are made.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "[for a removed member] For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\".")
+    public void mucTestMemberListRemainingOccupantsInformedOfRevokeMemberOnlyRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-revoke-memberonly");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByOwner.grantMembership(List.of(targetAddress1, targetAddress2));
+
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final ResultSyncPoint<Presence, Exception> ownerSeesRevoke = new ResultSyncPoint<>();
+            final ResultSyncPoint<Presence, Exception> adminSeesRevoke = new ResultSyncPoint<>();
+            final StanzaFilter notificationFilter = new AndFilter(new FromMatchesFilter(targetMucAddress, false), StanzaTypeFilter.PRESENCE, new ExtensionElementFilter<>(MUCUser.class));
+            conOne.addAsyncStanzaListener(stanza -> ownerSeesRevoke.signal((Presence) stanza), notificationFilter);
+            conTwo.addAsyncStanzaListener(stanza -> adminSeesRevoke.signal((Presence) stanza), notificationFilter);
+
+            // Execute system under test.
+            mucAsSeenByAdmin.revokeMembership(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            final Presence ownerReceivedPresence = assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
+            final Presence adminReceivedPresence = assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
+            assertTrue(ownerReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conOne.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' revoking their membership (but it was not).");
+            assertTrue(adminReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' revoking their membership (but it was not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that sending an invitation in an open room does not automatically add the invitee to the member list.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.")
+    public void mucTestMemberListNoChangeWithInviteInOpenROom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-invite-open");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            mucAsSeenByOwner.invite(targetAddress, "Invitation as part of an integration test.");
+
+            // Verify result.
+            assertFalse(mucAsSeenByOwner.getMembers().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Did not expect '" + targetAddress + "' to be on the member list of open room '" + mucAddress + "' after they were invited by '" + conOne.getUser() + "' (but they are on the member list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when member list changes are made.
+     */
+    @SmackIntegrationTest(section = "9.5", quote = "If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\".")
+    public void mucTestMemberListOccupantsInformedOfGrantOpenRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-grant-open");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress1 = conThree.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress2 = JidCreate.entityBareFrom("test2@example.com");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget1.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesGrant = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void membershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget1.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void membershipGranted() {
+                    target1SeesGrant.signal();
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByAdmin.grantMembership(List.of(targetAddress1, targetAddress2));
+
+            // Verify result.
+            assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(adminSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(target1SeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -30,6 +30,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.List;
 
@@ -44,8 +45,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminModeratorListIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -1,0 +1,640 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.8 Admin Use Cases: Modifying the Moderator List" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymod">XEP-0045 Section 9.8</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminModeratorListIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Asserts that a moderator list can be obtained.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = " the admin [...] requests the moderator list by querying the room for all users with a role of 'moderator'.")
+    public void mucTestAdminRequestsModeratorList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-moderatorlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCRole.moderator));
+            conTwo.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+        } catch (XMPPException.XMPPErrorException e) {
+            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the moderator list from '" + mucAddress + "' (but the server returned an error).", e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a moderator list item has 'nick' and 'role' attributes.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "each item MUST include the 'nick' and 'role' attributes")
+    public void mucTestAdminModeratorListItemCheck() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-not-on-moderator-list");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByAdmin.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCRole.moderator));
+            final MUCAdmin response = conTwo.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getNick() == null), "The moderator list for '" + mucAddress + "' contains an item that does not have a 'nick' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getRole() == null), "The moderator list for '" + mucAddress + "' contains an item that does not have a 'role' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getNick().equals(nicknameTarget)), "Expected the moderator list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include '" + nicknameTarget + "' (but it did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a moderator list modification can contain more than one item.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. In order to do so, the admin MUST send the changed items [...] back to the service [...] The service MUST modify the moderator list and then inform the admin of success")
+    public void mucTestAdminModeratorListMultipleItems() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget1));
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget2));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget1 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (but does not appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget2 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (but does not appear on the moderator list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a moderator list modification can be used to remove people from the moderator list.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. [...] set to a value of \"moderator\" to grant moderator status or \"participant\" to revoke moderator status)")
+    public void mucTestAdminModeratorListMultipleItemsRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(List.of(nicknameTarget1, nicknameTarget2));
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' and/or '" + conThree + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTarget1));
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTarget2));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget1 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (but does appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget2 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (but does appear on the moderator list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a moderator list modification is a delta: it shouldn't affect entries already on the moderator list
+     * that are not included in the delta.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\")")
+    public void mucTestAdminModeratorListIsDelta() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-delta");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(nicknameTarget1);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTarget1));
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget2));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameOwner)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameOwner + "' after the moderator list that previously contained them got updated with different items (which should have been applied as a delta).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget1 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (but does appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget2 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (but does not appear on the moderator list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when moderator list changes are made.
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list [...] The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas")
+    public void mucTestAdminModeratorListBroadcast() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(nicknameTarget1);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesGrantTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesGrantTarget2.signal();
+                    }
+                }
+
+                @Override
+                public void moderatorRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesRevokeTarget1.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget1.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void moderatorRevoked() {
+                    target1SeesRevokeTarget1.signal();
+                }
+            });
+            mucAsSeenByTarget1.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        target1SeesGrantTarget2.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget2.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void moderatorGranted() {
+                    target2SeesGrantTarget2.signal();
+                }
+            });
+            mucAsSeenByTarget2.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        target2SeesRevokeTarget1.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTarget1));
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget2));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+
+            assertResult(ownerSeesRevokeTarget1, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget1 + "' (but did not).");
+            assertResult(ownerSeesGrantTarget2, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget2 + "' (but did not).");
+            assertResult(target1SeesRevokeTarget1, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status for themself (but did not).");
+            assertResult(target1SeesGrantTarget2, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget2 + "' (but did not).");
+            assertResult(target2SeesRevokeTarget1, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget1 + "' (but did not).");
+            assertResult(target2SeesGrantTarget2, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status for themself' (but did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin cannot revoke moderator status from another admin
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "[...] moderator status cannot be revoked from a [...] room admin. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a <not-allowed/> error to the sender")
+    public void testAdminNotAllowedToRevokeModeratorFromAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-admin-rejected");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTargetAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTargetAdmin = Resourcepart.from("targetAdmin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetAdminMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTargetAdmin);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+
+            final SimpleResultSyncPoint ownerSeesTargetAdmin = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetAdminMucAddress)) {
+                        ownerSeesTargetAdmin.signal();
+                    }
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTargetAdmin.join(nicknameTargetAdmin);
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTargetAdmin.waitForResult(timeout);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTargetAdmin)); // Should be rejected
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget)); // Should be valid
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conOne.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conOne.getUser() + "' to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameTargetAdmin + "' which is an admin in room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameTargetAdmin + "', another admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin cannot revoke moderator status from an owner
+     */
+    @SmackIntegrationTest(section = "9.8", quote = "[...] moderator status cannot be revoked from a room owner [...]. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a <not-allowed/> error to the sender")
+    public void testAdminNotAllowedToRevokeModeratorFromOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-owner-rejected");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTargetOwner = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTargetOwner = Resourcepart.from("targetOwner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetOwnerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTargetOwner);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
+                    mucAsSeenByOwner.grantModerator(nicknameOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByOwner.grantOwnership(conTwo.getUser().asBareJid());
+
+            final SimpleResultSyncPoint ownerSeesTargetAdmin = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetOwnerMucAddress)) {
+                        ownerSeesTargetAdmin.signal();
+                    }
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTargetOwner.join(nicknameTargetOwner);
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTargetAdmin.waitForResult(timeout);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTargetOwner)); // Should be rejected
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget)); // Should be valid
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conOne.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conOne.getUser() + "' to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameTargetOwner + "' that is an owner in room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameTargetOwner + "', that is an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
@@ -1,0 +1,411 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.filter.AndFilter;
+import org.jivesoftware.smack.filter.FromMatchesFilter;
+import org.jivesoftware.smack.filter.PresenceTypeFilter;
+import org.jivesoftware.smack.filter.StanzaFilter;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Presence;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jivesoftware.smackx.muc.packet.MUCUser;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.4 Admin Use Cases: Revoking Membership" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemember">XEP-0045 Section 9.4</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminRevokeMemberIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that an admin can revoke membership of a user.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; this is done by changing the user's affiliation to \"none\"")
+    public void testRevokeMembership() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.grantMembership(targetAddress);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.none, targetAddress));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke membership from '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+
+    /**
+     * Verifies that an admin can revoke membership from a user while providing an optional reason.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeMembershipWithReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.grantMembership(targetAddress);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.none, null, null, "Revoke membership as part of a test.", targetAddress, null, null));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke membership (using the optional 'reason' element) from '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot revoke someone's membership.
+     */
+    @SmackIntegrationTest(section = "9", quote = "[...] revoke membership [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToRevokeMembership() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantMembership(targetAddress);
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.none, null, null, null, targetAddress, null, null));
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to revoke membership from another participant ('" + targetAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke membership from another participant ('" + targetAddress + "') for room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a bare JID (of an occupant) from which membership is revoked by an admin no longer appears on the Member List.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; [...] The service MUST remove the user from the member list [...] ")
+    public void testMemberNotOnMemberList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-not-on-memberlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.grantMembership(targetAddress);
+
+            // Execute system under test.
+            try {
+                mucAsSeenByAdmin.revokeMembership(targetAddress);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to revoke membership from '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(mucAsSeenByAdmin.getMembers().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress + "' to no longer be on the Member List after their membership was revoked by '" + conTwo + "' from '" + mucAddress + "' (but the JID does appear on the Member List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when membership is revoked from an existing occupant.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; [...] The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\".")
+    public void mucTestOccupantsInformedRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberrevoke-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            mucAsSeenByAdmin.grantMembership(targetAddress);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant)
+                {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener()
+            {
+                @Override
+                public void membershipRevoked()
+                {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void membershipRevoked(EntityFullJid participant)
+                {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void membershipRevoked(EntityFullJid participant)
+                {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesRevoke.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            try {
+                mucAsSeenByAdmin.revokeMembership(targetAddress);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to revoke membership from '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of membership, after it was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of membership, after '" + targetAddress + "' was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of membership, after '" + targetAddress + "' was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a user from which membership is revoked is kicked from the room, if the room is members-only.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; [...] If the room is members-only, the service MUST remove the user from the room, including a status code of 321 [...]")
+    public void mucTestRemovalOfUserInMembersOnlyRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-revoke-removal");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantMembership(targetAddress);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant)
+                {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            ResultSyncPoint<Presence, Exception> targetSeesRemoval = new ResultSyncPoint<>();
+            final StanzaFilter leaveRoomFilter = new AndFilter(new FromMatchesFilter(targetMucAddress, false), PresenceTypeFilter.UNAVAILABLE);
+            conThree.addAsyncStanzaListener(stanza -> targetSeesRemoval.signal((Presence) stanza), leaveRoomFilter);
+
+            // Execute system under test.
+            mucAsSeenByOwner.revokeMembership(targetAddress);
+
+            // Verify result
+            final Presence presence = assertResult(targetSeesRemoval, "Expected '" + conThree.getUser() + "' to receive a presence 'unavailable' stanza from room '" + mucAddress + "' indicating that they removed from the room, after '" + conOne.getUser() + "' revoked their membership from the (members-only) room (but that presence stanza did not arrive).");
+            final MUCUser extension = presence.getExtension(MUCUser.class);
+            assertNotNull(extension, "Expected an <x/> child element qualified by the 'http://jabber.org/protocol/muc#user' namespace to exist in the presence stanza received by '" + conThree.getUser() + "' when they were removed from members-only room '" + mucAddress + "' when '" + conOne.getUser() + "' revoked their membership (but no such child element was detected).");
+            assertTrue(extension.getItem() != null && extension.getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conThree.getUser() + "' when they were removed from members-only room '" + mucAddress + "' when '" + conOne.getUser() + "' revoked their membership (but it was not).");
+            assertTrue(extension.getStatus().stream().anyMatch(status -> status.getCode() == 321), "Expected to find status code 321 in the presence stanza received by '" + conThree.getUser() + "' when they were removed from members-only room '" + mucAddress + "' when '" + conOne.getUser() + "' revoked their membership (but it was not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that other occupants are notified when a user is kicked from a members-only room whein their membership is revoked.
+     */
+    @SmackIntegrationTest(section = "9.4", quote = "An admin might want to revoke a user's membership; [...] If the room is members-only, the service MUST remove the user from the room, including a status code of 321 [...] and inform all remaining occupants")
+    public void mucTestOccupantsInformedKick() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-revoke-removal-notif");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final EntityBareJid memberAddress = conTwo.getUser().asEntityBareJid();
+        final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameMember = Resourcepart.from("member-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantMembership(memberAddress);
+            mucAsSeenByOwner.grantMembership(targetAddress);
+            mucAsSeenByMember.join(nicknameMember);
+
+            final SimpleResultSyncPoint memberSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByMember.addParticipantStatusListener(new ParticipantStatusListener()
+            {
+                @Override
+                public void joined(EntityFullJid participant)
+                {
+                    if (participant.equals(targetMucAddress)) {
+                        memberSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            memberSeesTarget.waitForResult(timeout);
+
+            ResultSyncPoint<Presence, Exception> memberSeesRemoval = new ResultSyncPoint<>();
+            final StanzaFilter leaveRoomFilter = new AndFilter(new FromMatchesFilter(targetMucAddress, false), PresenceTypeFilter.UNAVAILABLE);
+            conTwo.addAsyncStanzaListener(stanza -> memberSeesRemoval.signal((Presence) stanza), leaveRoomFilter);
+
+            // Execute system under test.
+            mucAsSeenByOwner.revokeMembership(targetAddress);
+
+            // Verify result
+            final Presence presence = assertResult(memberSeesRemoval, "Expected '" + conTwo.getUser() + "' to receive a presence 'unavailable' stanza from room '" + mucAddress + "' indicating that '" + conThree.getUser() + "' was removed from the room, as a result of '" + conOne.getUser() + "' revoking their membership from the (members-only) room (but that presence stanza did not arrive).");
+            final MUCUser extension = presence.getExtension(MUCUser.class);
+            assertNotNull(extension, "Expected an <x/> child element qualified by the 'http://jabber.org/protocol/muc#user' namespace to exist in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conOne.getUser() + "' revoking their membership (but no such child element was detected).");
+            assertTrue(extension.getItem() != null && extension.getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conOne.getUser() + "' revoking their membership (but it was not).");
+            assertTrue(extension.getStatus().stream().anyMatch(status -> status.getCode() == 321), "Expected to find status code 321 in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conOne.getUser() + "' revoking their membership (but it was not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
@@ -37,6 +37,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -49,8 +50,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeMemberIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -30,6 +30,7 @@ import org.jxmpp.jid.EntityBareJid;
 import org.jxmpp.jid.EntityFullJid;
 import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.List;
 
@@ -44,8 +45,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
-        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         super(environment);
     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -1,0 +1,485 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "9.7 Admin Use Cases: Revoking Moderator Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemod">XEP-0045 Section 9.7</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatAdminRevokeModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that an admin can revoke moderator status of a user.
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "An admin might want to revoke a user's moderator status. [...] The status is revoked by changing the user's role to \"participant\"")
+    public void testRevokeModerator() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByAdmin.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.participant, nicknameTarget));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin can revoke moderator status of a user.
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "An admin might want to revoke a user's moderator status. [...] The status is revoked by changing the user's role to \"participant\" [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeModeratorWithReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByAdmin.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.participant, nicknameTarget, "Revoking moderator status as part of an integration test."));
+
+            try {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status (using the optional 'reason' element) from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-admin cannot revoke someone's moderator status.
+     */
+    @SmackIntegrationTest(section = "9", quote = "[...] revoke moderator status [...] MUST be denied if the <user@host> of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a <forbidden/> error.")
+    public void testParticipantNotAllowedToRevokeModerator() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected owner '" + conOne.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.participant, nicknameTarget));
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to revoke moderator status from another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke moderator status from another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' while not being an admin.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a participant that got its moderator status removed no longer exists on the moderator list.
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "An admin might want to revoke a user's moderator status. [...] The service MUST remove the user from the moderator list [...] ")
+    public void testModeratorNotOnModeratorList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-not-on-moderator-list");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByAdmin.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Execute system under test.
+            try {
+                mucAsSeenByAdmin.revokeModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to no longer be on the Moderator List after their moderator status was revoked by '" + conTwo + "' from '" + mucAddress + "' (but their nickname does appear on the Moderator List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when moderator status is revoked from an occupant.
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator status by sending a presence element that contains an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'role' attribute set to a value of \"participant\".")
+    public void mucTestOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByAdmin.grantModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener()
+            {
+                @Override
+                public void moderatorRevoked()
+                {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void moderatorRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        adminSeesRevoke.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            try {
+                mucAsSeenByAdmin.revokeModerator(nicknameTarget);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after their status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin cannot revoke moderator status from another admin
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "[...] an admin MUST NOT be allowed to revoke moderator status from a user whose affiliation is [...] \"admin\". If an admin attempts to revoke moderator status from such a user, the service MUST deny the request and return a <not-allowed/> error to the sender")
+    public void testAdminNotAllowedToRevokeModeratorFromAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-admin-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("targetadmin-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(List.of(conTwo.getUser().asBareJid(), conThree.getUser().asBareJid()));
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(List.of(nicknameAdmin, nicknameTarget));
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected owner '" + conOne.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' and '" + nicknameAdmin +"' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.participant, nicknameTarget));
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is an admin) tried to revoke moderator status from another admin ('" + targetMucAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is an admin) after it tried to revoke moderator status from another admin ('" + targetMucAddress + "') for room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an admin cannot revoke moderator status from an owner.
+     */
+    @SmackIntegrationTest(section = "9.7", quote = "[...] an admin MUST NOT be allowed to revoke moderator status from a user whose affiliation is \"owner\" [...]. If an admin attempts to revoke moderator status from such a user, the service MUST deny the request and return a <not-allowed/> error to the sender")
+    public void testAdminNotAllowedToRevokeModeratorFromOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-owner-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("targetowner-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantOwnership(conThree.getUser().asBareJid());
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint adminSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            adminSeesTarget.waitForResult(timeout);
+
+            try {
+                mucAsSeenByOwner.grantModerator(List.of(nicknameAdmin, nicknameTarget));
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected owner '" + conOne.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' and '" + nicknameAdmin +"' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCRole.participant, nicknameTarget));
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is an admin) tried to revoke moderator status from an owner ('" + targetMucAddress + "') for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is an admin) after it tried to revoke moderator status from an owner ('" + targetMucAddress + "') for room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}


### PR DESCRIPTION
I'm opening this PR as a draft (for your reviewing pleasure) as I've completed a boatload of tests for sections 9.1 through 9.5. On the to-do list are sections 9.6 to 9.9.

Some of these tests are expected to fail when executing against Openfire versions before 4.8.3 (because of https://igniterealtime.atlassian.net/browse/OF-2843 and https://igniterealtime.atlassian.net/browse/OF-2844).