### PR TITLE
Improve test run output on standard-out

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
           -Dsinttest.enabledConnections=tcp \
           -Dsinttest.dnsResolver=javax \
           -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest" \
-          -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.SmackIntegrationTestFramework\$JulTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
+          -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
           -Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory" \
           -DlogDir=logs \
           -jar $JARFILE

--- a/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/FileLogger.java
@@ -45,8 +45,26 @@ public class FileLogger extends AbstractDebugger
             formatedDate = dateFormatter.format(new Date());
         }
 
-        String filename;
         final SmackIntegrationTestFramework.ConcreteTest testUnderExecution = SmackIntegrationTestFramework.getTestUnderExecution();
+        final Path logPath = getLog(logDir, testUnderExecution);
+
+        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(logPath.toFile(), true), StandardCharsets.UTF_8);
+             final BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
+            bufferedWriter.write(formatedDate + ' ' + logMessage + System.lineSeparator());
+        } catch (IOException e) {
+            System.err.println("Unable to write log to file " + logPath);
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void log(String logMessage, Throwable throwable) {
+        String stacktrace = ExceptionUtil.getStackTrace(throwable);
+        log(logMessage + '\n' + stacktrace);
+    }
+
+    public static Path getLog(final Path logDir, final SmackIntegrationTestFramework.ConcreteTest testUnderExecution) {
+        String filename;
         if (testUnderExecution != null) {
             filename = testUnderExecution.toString();
         } else {
@@ -60,20 +78,6 @@ public class FileLogger extends AbstractDebugger
         } else {
             logPath = Paths.get(filename);
         }
-
-        try (final Writer writer = new OutputStreamWriter(new FileOutputStream(logPath.toFile(), true), StandardCharsets.UTF_8);
-             final BufferedWriter bufferedWriter = new BufferedWriter(writer)) {
-            bufferedWriter.write(formatedDate + ' ' + logMessage + System.lineSeparator());
-        } catch (IOException e) {
-            System.err.println("Unable to write log to file " + filename);
-            e.printStackTrace();
-        }
+        return logPath;
     }
-
-    @Override
-    protected void log(String logMessage, Throwable throwable) {
-        String stacktrace = ExceptionUtil.getStackTrace(throwable);
-        log(logMessage + '\n' + stacktrace);
-    }
-
 }

--- a/src/main/java/org/igniterealtime/smack/inttest/util/JUnitXmlTestRunResultProcessor.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/JUnitXmlTestRunResultProcessor.java
@@ -319,15 +319,19 @@ public class JUnitXmlTestRunResultProcessor implements SmackIntegrationTestFrame
         return allTestResults.stream().collect(Collectors.groupingBy(e -> getSpecificationReference(e.concreteTest.getMethod())));
     }
 
-    private static String getSpecificationReference(Method method) {
-        final SpecificationReference spec = method.getDeclaringClass().getAnnotation(SpecificationReference.class);
+    public static String getSpecificationReference(Class<?> clazz) {
+        final SpecificationReference spec = clazz.getAnnotation(SpecificationReference.class);
         if (spec == null || spec.document().isBlank()) {
             return "";
         }
         return normalizeSpecification(spec.document().trim());
     }
 
-    private static String getSpecificationSection(Method method) {
+    public static String getSpecificationReference(Method method) {
+        return getSpecificationReference(method.getDeclaringClass());
+    }
+
+    public static String getSpecificationSection(Method method) {
         final SmackIntegrationTest test = method.getAnnotation(SmackIntegrationTest.class);
         if (!test.section().isBlank()) {
             return test.section().trim();
@@ -335,7 +339,7 @@ public class JUnitXmlTestRunResultProcessor implements SmackIntegrationTestFrame
         return null;
     }
 
-    private static String getSpecificationQuote(Method method) {
+    public static String getSpecificationQuote(Method method) {
         final SmackIntegrationTest test = method.getAnnotation(SmackIntegrationTest.class);
         if (!test.quote().isBlank()) {
             return test.quote().trim();

--- a/src/main/java/org/igniterealtime/smack/inttest/util/StdOutTestRunResultProcessor.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/StdOutTestRunResultProcessor.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.igniterealtime.smack.inttest.util;
+
+import org.igniterealtime.smack.inttest.*;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+
+public class StdOutTestRunResultProcessor implements SmackIntegrationTestFramework.TestRunResultProcessor
+{
+    @Override
+    public void process(final SmackIntegrationTestFramework.TestRunResult testRunResult)
+    {
+        final int successfulTests = testRunResult.getSuccessfulTests().size();
+        final int failedTests = testRunResult.getFailedTests().size();
+        final int impossibleTests = testRunResult.getNotPossibleTests().size() + getMethodsInImpossibleTestClasses(testRunResult.getImpossibleTestClasses().keySet()).size();
+
+        System.out.println();
+        System.out.println("Test run (id :" + testRunResult.testRunId + ") finished! " + successfulTests + " tests were successful (✔), " + failedTests + " failed (\uD83D\uDC80), and " + impossibleTests + " were impossible to run (✖).");
+        System.out.println();
+        System.out.println("Results aggregated by specification:");
+
+        final Map<String, Collection<SuccessfulTest>> successFulTestsBySpec = aggregateBySpecification(testRunResult.getSuccessfulTests());
+        final Map<String, Collection<FailedTest>> failedTestsBySpec = aggregateBySpecification(testRunResult.getFailedTests());
+        final Map<String, Collection<TestNotPossible>> impossibleTestsBySpec = aggregateBySpecification(testRunResult.getNotPossibleTests());
+        final Map<String, Collection<Class<? extends AbstractSmackIntTest>>> impossibleTestClassesBySpec = aggregateBySpecification(testRunResult.getImpossibleTestClasses().keySet());
+
+        final SortedSet<String> specifications = new TreeSet<>();
+        specifications.addAll(successFulTestsBySpec.keySet());
+        specifications.addAll(failedTestsBySpec.keySet());
+        specifications.addAll(impossibleTestsBySpec.keySet());
+        specifications.addAll(impossibleTestClassesBySpec.keySet());
+        final int longestSpecCharCount = specifications.stream().map(String::length).max(Integer::compareTo).orElse(0);
+        final int longestSuccCharCount = successFulTestsBySpec.values().stream().map(Collection::size).map(i->i.toString().length()).max(Integer::compareTo).orElse(0);
+        final int longestFailCharCount = failedTestsBySpec.values().stream().map(Collection::size).map(i->i.toString().length()).max(Integer::compareTo).orElse(0);
+        for (final String specification : specifications) {
+            final int success = successFulTestsBySpec.getOrDefault(specification, Collections.emptySet()).size();
+            final int fail = failedTestsBySpec.getOrDefault(specification, Collections.emptySet()).size();
+            final int impossible = impossibleTestsBySpec.getOrDefault(specification, Collections.emptySet()).size() + getMethodsInImpossibleTestClasses(impossibleTestClassesBySpec.getOrDefault(specification, Collections.emptySet())).size();
+            final String title = (specification.isEmpty() ? "(noname)" : specification);
+            System.out.println("• " + String.format("%" + (Math.max(longestSpecCharCount, "(noname)".length()))+"s", title) + " " + String.format("%"+longestSuccCharCount+"s", success) + " ✔  " + String.format("%"+longestFailCharCount+"s", fail) + " \uD83D\uDC80 " + String.format("%3s", impossible) + " ✖");
+        }
+
+        if (!impossibleTestsBySpec.isEmpty() || !impossibleTestClassesBySpec.isEmpty()) {
+            System.out.println();
+            System.out.println("✖ The following tests were impossible to run! ✖");
+
+            for (final Map.Entry<String, Collection<TestNotPossible>> entry : impossibleTestsBySpec.entrySet()) {
+                final String title = (entry.getKey().isEmpty() ? "(noname)" : entry.getKey());
+                final Map<String, Long> reasonCount = entry.getValue().stream().collect(Collectors.groupingBy(t -> t.testNotPossibleException.getMessage(), Collectors.counting()));
+                for (final Map.Entry<String, Long> reasonEntry : reasonCount.entrySet()) {
+                    System.out.println("• " + String.format("%" + (Math.max(longestSpecCharCount, "(noname)".length())) + "s", title) + ": could not run " + entry.getValue().size() + " test(s) because: " + reasonEntry.getKey());
+                }
+            }
+            for (final Map.Entry<String, Collection<Class<? extends AbstractSmackIntTest>>> entry : impossibleTestClassesBySpec.entrySet()) {
+                final String title = (entry.getKey().isEmpty() ? "(noname)" : entry.getKey());
+                final Collection<Class<? extends AbstractSmackIntTest>> classes = entry.getValue();
+                final SortedMap<String, Integer> counts = new TreeMap<>();
+                for (final Class<? extends AbstractSmackIntTest> clazz : classes) {
+                    final String reason = testRunResult.getImpossibleTestClasses().get(clazz).getLocalizedMessage();
+                    final int count = getMethodsInImpossibleTestClass(clazz).size();
+                    int c = counts.getOrDefault(reason, 0);
+                    c += count;
+                    counts.put(reason, c);
+                }
+                for (Map.Entry<String, Integer> e : counts.entrySet()) {
+                    System.out.println("• " + String.format("%" + (Math.max(longestSpecCharCount, "(noname)".length())) + "s", title) + ": could not run " + e.getValue() + " test(s) because: " + e.getKey());
+                }
+            }
+        }
+
+
+        if (!failedTestsBySpec.isEmpty()) {
+            System.out.println();
+            System.out.println("💀 The following " + failedTests + " tests failed! 💀");
+
+            final SortedMap<String, Collection<FailedTest>> sortedFailedTestBySpec = new TreeMap<>(failedTestsBySpec);
+            for (final Map.Entry<String, Collection<FailedTest>> entry : sortedFailedTestBySpec.entrySet()) {
+                final String title = entry.getKey();
+                for (final FailedTest failedTest : entry.getValue()) {
+                    // TODO sort on spec and section
+                    final String sectionReference = JUnitXmlTestRunResultProcessor.getSpecificationSection(failedTest.concreteTest.getMethod());
+                    final String quote = JUnitXmlTestRunResultProcessor.getSpecificationQuote(failedTest.concreteTest.getMethod());
+                    final Path logPath = FileLogger.getLog(System.getProperty("logDir") == null ? null : Paths.get(System.getProperty("logDir")), failedTest.concreteTest);
+                    System.out.println("• " + (sectionReference == null ? title : title + ", section " + sectionReference) + " \"" + quote + "\"");
+                    System.out.println("  Failure reason  : " + failedTest.failureReason.getMessage());
+                    System.out.println("  Stanza log file : " + logPath);
+                    System.out.println("  Test class      : " + failedTest.concreteTest.getMethod().getDeclaringClass());
+                    System.out.println("  Test method     : " + failedTest.concreteTest.getMethod().getName());
+                    System.out.println();
+                }
+            }
+        }
+    }
+
+    public static List<Method> getMethodsInImpossibleTestClasses(Collection<Class<? extends AbstractSmackIntTest>> testClasses)
+    {
+        final List<Method> result = new ArrayList<>();
+        for (final Class<? extends AbstractSmackIntTest> testClass : testClasses) {
+            result.addAll(getMethodsInImpossibleTestClass(testClass));
+        }
+        return result;
+    }
+
+    public static List<Method> getMethodsInImpossibleTestClass(Class<? extends AbstractSmackIntTest> testClass) {
+        Method[] testClassMethods = testClass.getMethods();
+        List<Method> smackIntegrationTestMethods = new ArrayList<>(testClassMethods.length);
+        for (Method method : testClassMethods) {
+            if (!method.isAnnotationPresent(SmackIntegrationTest.class)) {
+                continue;
+            }
+            smackIntegrationTestMethods.add(method);
+        }
+        return smackIntegrationTestMethods;
+    }
+
+    public static <T extends TestResult> Map<String, Collection<T>> aggregateBySpecification(final Collection<T> testResults) {
+        final ConcurrentMap<String, Collection<T>> result = new ConcurrentHashMap<>();
+        for (final T testResult : testResults) {
+            String specificationReference = JUnitXmlTestRunResultProcessor.getSpecificationReference(testResult.concreteTest.getMethod());
+            specificationReference = humanReadibleSpec(specificationReference);
+            result.computeIfAbsent(specificationReference, s -> new LinkedList<>()).add(testResult);
+        }
+        return result;
+    }
+
+    private Map<String, Collection<Class<? extends AbstractSmackIntTest>>> aggregateBySpecification(Set<Class<? extends AbstractSmackIntTest>> classes)
+    {
+        final Map<String, Collection<Class<? extends AbstractSmackIntTest>>> result = new ConcurrentHashMap<>();
+        for (final Class<? extends AbstractSmackIntTest> clazz : classes) {
+            String specificationReference = JUnitXmlTestRunResultProcessor.getSpecificationReference(clazz);
+            specificationReference = humanReadibleSpec(specificationReference);
+            result.computeIfAbsent(specificationReference, s -> new LinkedList<>()).add(clazz);
+        }
+        return result;
+    }
+
+    public static String humanReadibleSpec(final String spec) {
+        return spec.replaceFirst("^XEP", "XEP-").replaceFirst("^RFC", "RFC ");
+    }
+}


### PR DESCRIPTION
The output as printed on standard-out should facilitate viewers in debugging their code on test failures.

It needs to be as easy as possible to determine for each test failure:
- which specification was the subject of the test, containing a specification reference and a direct quote of the relevant text.
- what test assertion failed
- where the XMPP stanza log is for the test that fails.

Viewers need not be familiar with our test implementations (or even Smack, or Java). We can/should still reference the implementation as a last resort.

This is achieved by replacing SINT's standard Test Run Result processor (`org.igniterealtime.smack.inttest.SmackIntegrationTestFramework\$JulTestRunResultProcessor`) with a new, custom implementation: `org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor`