### PR TITLE
Add tests for XEP-0045 Multi-User Chat (section 10)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build & Test
 
 on: [pull_request]
 
-env:
-  OPENFIRE_VERSION: 4_8_3 # The version of Openfire to use, using underscores, to match artifact filenames in https://github.com/igniterealtime/Openfire/releases/
-
 permissions:
   checks: write
 
@@ -44,16 +41,23 @@ jobs:
           repository: igniterealtime/Openfire
           sparse-checkout: |
             .github
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         id: cache
         with:
           path: openfire.tar.gz
-          key: openfire-${{env.OPENFIRE_VERSION}}
-      - name: Download Openfire
+          key: openfire-daily-${{env.NOW}}
+      - name: Download a recent Openfire daily build.
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          DOTTED_VERSION=$(echo ${{env.OPENFIRE_VERSION}} | tr _ .)
-          curl -L https://github.com/igniterealtime/Openfire/releases/download/v$DOTTED_VERSION/openfire_${{env.OPENFIRE_VERSION}}.tar.gz -o openfire.tar.gz
+          # This tries to find the most recent daily build, going back 30 days if none are available.
+          #Note that the cache above will cause whatever build that's download to be considered 'todays' build.
+          for i in $(seq 0 30); do
+            STAMP=`date --date="$i day ago" +%F`;
+            echo "Attempting to download Openfire build for $STAMP"
+            curl --fail -L "https://download.igniterealtime.org/openfire/dailybuilds/openfire_$STAMP.tar.gz" -o openfire.tar.gz && break
+          done
       - name: Extract Openfire
         run: |
           tar -xzf openfire.tar.gz
@@ -133,16 +137,23 @@ jobs:
           repository: igniterealtime/Openfire
           sparse-checkout: |
             .github
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         id: cache
         with:
           path: openfire.tar.gz
-          key: openfire-${{env.OPENFIRE_VERSION}}
-      - name: Download Openfire
+          key: openfire-daily-${{env.NOW}}
+      - name: Download a recent Openfire daily build.
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
-          DOTTED_VERSION=$(echo ${{env.OPENFIRE_VERSION}} | tr _ .)
-          curl -L https://github.com/igniterealtime/Openfire/releases/download/v$DOTTED_VERSION/openfire_${{env.OPENFIRE_VERSION}}.tar.gz -o openfire.tar.gz
+          # This tries to find the most recent daily build, going back 30 days if none are available.
+          #Note that the cache above will cause whatever build that's download to be considered 'todays' build.
+          for i in $(seq 0 30); do
+            STAMP=`date --date="$i day ago" +%F`;
+            echo "Attempting to download Openfire build for $STAMP"
+            curl --fail -L "https://download.igniterealtime.org/openfire/dailybuilds/openfire_$STAMP.tar.gz" -o openfire.tar.gz && break
+          done
       - name: Extract Openfire
         run: |
           tar -xzf openfire.tar.gz

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
@@ -1,0 +1,591 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.8 Owner Use Cases: Modifying the Admin List" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyadmin">XEP-0045 Section 10.8</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerAdminListIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads (in section 5.2) "Support for the admin [...] is RECOMMENDED."
+        // which suggests that this is optional functionality. The specification does not explicitly say how to test for
+        // support. This implementation will use any XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.grantAdmin(conTwo.getUser().asBareJid());
+            muc.revokeAdmin(conTwo.getUser().asEntityBareJid());
+        } catch (XMPPException.XMPPErrorException e) {
+            if (StanzaError.Condition.not_authorized.equals(e.getStanzaError().getCondition())) {
+                throw new TestNotPossibleException("Service does not support granting and/or revokation of admin status functionality.");
+            } else {
+                throw e;
+            }
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Asserts that an admin list can be obtained.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "the owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'.")
+    public void testOwnerRequestsAdminList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-requests-adminlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.admin));
+            conOne.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+        } catch (XMPPException.XMPPErrorException e) {
+            fail("Expected owner '" + conOne.getUser() + "' to be able to receive the admin list from '" + mucAddress + "' (but the server returned an error).", e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a user (not in the room, that is semi-anonymous) cannot request the admin list.
+     *
+     * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserRequestsAdminList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-adminlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createSemiAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.admin));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not in the room) to receive an error when requesting the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not in the room) after it requested the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a participant (that is in a semi-anonymous room) cannot request the admin list.
+     *
+     * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantRequestsAdminList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-adminlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createSemiAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.admin));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected participant '" + conTwo.getUser() + "' to receive an error when requesting the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is a participant in the room) after it requested the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin list item has 'affiliation' and 'jid' attributes.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    public void testAdminListItemCheck() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-list-itemcheck");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.admin));
+            final MUCAdmin response = conOne.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The admin list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The admin list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the admin list requested by '" + conOne.getUser() + "' from '" + mucAddress + "' to include '" + conTwo.getUser().asBareJid() + "' (but it did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin list modification can contain more than one item.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items [...] back to the service [...] the service MUST modify admin list and then inform the owner of success")
+    public void testAdminListMultipleItems() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the admin list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to contain '" + conTwo.getUser().asBareJid() + "' that was just added to the admin list by '" + conOne.getUser() + "' (but does not appear on the admin list).");
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to contain '" + conThree.getUser().asBareJid() + "' that was just added to the admin list by '" + conOne.getUser() + "' (but does not appear on the admin list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin list modification can be used to remove people from the admin list.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items [...] back to the service [...] the service MUST modify admin list and then inform the owner of success")
+    public void testAdminAdminListMultipleItemsRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantAdmin(List.of(conTwo.getUser().asBareJid(), conThree.getUser().asBareJid()));
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' and/or '" + conThree.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the admin list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to not contain '" + conTwo.getUser().asBareJid() + "' that was just removed from the admin list by '" + conOne.getUser() + "' (but does appear on the admin list).");
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to not contain '" + conThree.getUser().asBareJid() + "' that was just removed from the admin list by '" + conOne.getUser() + "' (but does appear on the admin list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin list modification is a delta: it shouldn't affect entries already on the admin list
+     * that are not included in the delta.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "The owner can then modify the admin list if desired. In order to do so, the owner MUST send the changed items (i.e., only the \"delta\")")
+    public void testOwnerAdminListIsDelta() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-delta");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the admin list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to no longer contain '" + conTwo.getUser().asBareJid() + "' that was just removed from the admin list by '" + conOne.getUser() + "' (but does still appear on the admin list).");
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.admin && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the admin list for '" + mucAddress + "' to contain '" + conThree.getUser().asBareJid() + "' that was just added to the admin list by '" + conOne.getUser() + "' (but does not appear on the admin list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin (non-owner) cannot make an admin list modification.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    public void testAdminListRejectAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-admin");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByAdmin.join(nicknameAdmin); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but an admin) to receive an error when they attempted to modify the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but an admin) after it attempted to modify the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member (non-owner) cannot make an admin list modification.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    public void testAdminListRejectMember() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-member");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameMember = Resourcepart.from("member-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantMembership(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' membership in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByMember.join(nicknameMember); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but a member) to receive an error when they attempt to modify the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but a member) after it attempted to modify the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an outcast (non-owner) cannot make an admin list modification.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    public void testAdminListRejectOutcast() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-member");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.banUser(conTwo.getUser().asBareJid(), "Made outcast as part of an integration test.");
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to make '" + conTwo.getUser().asBareJid() + "' an outcast in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but an outcast) to receive an error when they attempt to modify the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but an outcast) after it attempted to modify the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a user without an affiliation (non-owner) cannot make an admin list modification.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    public void testAdminListRejectNoneAffiliation() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-nonaff");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but a user without an affiliation) to receive an error when they attempt to modify the admin list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but a user without an affiliation) after it attempted to modify the admin list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when admin list changes are made.
+     */
+    @SmackIntegrationTest(section = "10.8", quote = "The service MUST also send presence notifications related to any affiliation changes that result from modifying the admin list [...]")
+    public void testAdminAdminListBroadcast() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesGrantTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesGrantTarget2.signal();
+                    }
+                }
+
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesRevokeTarget1.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget1.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminRevoked() {
+                    target1SeesRevokeTarget1.signal();
+                }
+            });
+            mucAsSeenByTarget1.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        target1SeesGrantTarget2.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget2.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminGranted() {
+                    target2SeesGrantTarget2.signal();
+                }
+            });
+            mucAsSeenByTarget2.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        target2SeesRevokeTarget1.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the admin list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+
+            assertResult(ownerSeesRevokeTarget1, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status of '" + conTwo.getUser().asBareJid() + "' (but did not).");
+            assertResult(ownerSeesGrantTarget2, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status of '" + conThree.getUser().asBareJid() + "' (but did not).");
+            assertResult(target1SeesRevokeTarget1, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status for themself (but did not).");
+            assertResult(target1SeesGrantTarget2, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status of '" + conThree.getUser().asBareJid() + "' (but did not).");
+            assertResult(target2SeesRevokeTarget1, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status of '" + conTwo.getUser().asBareJid() + "' (but did not).");
+            assertResult(target2SeesGrantTarget2, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in admin status for themself' (but did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
@@ -74,7 +74,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an admin list can be obtained.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "the owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'.")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'.")
     public void testOwnerRequestsAdminList() throws Exception
     {
         // Setup test fixture.
@@ -106,7 +106,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
     public void testUserRequestsAdminList() throws Exception
     {
         // Setup test fixture.
@@ -138,7 +138,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
     public void testParticipantRequestsAdminList() throws Exception
     {
         // Setup test fixture.
@@ -172,7 +172,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an admin list item has 'affiliation' and 'jid' attributes.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list [...] the service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes")
     public void testAdminListItemCheck() throws Exception
     {
         // Setup test fixture.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -1,0 +1,1023 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.StanzaListener;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.filter.AndFilter;
+import org.jivesoftware.smack.filter.FromMatchesFilter;
+import org.jivesoftware.smack.filter.StanzaFilter;
+import org.jivesoftware.smack.filter.StanzaTypeFilter;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.filter.MUCUserStatusCodeFilter;
+import org.jivesoftware.smackx.muc.packet.MUCOwner;
+import org.jivesoftware.smackx.muc.packet.MUCUser;
+import org.jivesoftware.smackx.xdata.FormField;
+import org.jivesoftware.smackx.xdata.ListSingleFormField;
+import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.Form;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.3 Owner Use Cases: Subsequent Room Configuration" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#roomconfig">XEP-0045 Section 10.2</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerConfigRoomIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
+    {
+        super(environment);
+
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-setup");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+        } catch (Exception e) {
+            throw new TestNotPossibleException("The service at '" + mucAddress.asDomainBareJid() + "' does not allow for a room to be created." + e.getMessage());
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a user (without role or affiliation) different from the owner cannot request a room configuration form.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "a room owner requests a new configuration form [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testObtainRoomConfigWithoutRoleOrAffiliation() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-no-role-or-affiliation");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+            requestConfigurationFormStanza.setTo(mucAddress);
+            requestConfigurationFormStanza.setType(IQ.Type.get);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that has no role or affiliation) tried to get a room configuration form for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to get a room configuration form for room '" + mucAddress + "' while not having a role or affiliation for that room.");
+       } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a user (that is a participant) different from the owner cannot request a room configuration form.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "a room owner requests a new configuration form [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testObtainRoomConfigNonAffiliatedUser() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-participant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            mucManagerTwo.getMultiUserChat(mucAddress).join(nicknameParticipant);
+
+            final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+            requestConfigurationFormStanza.setTo(mucAddress);
+            requestConfigurationFormStanza.setType(IQ.Type.get);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is a participant but no owner) tried to get a room configuration form for room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to get a room configuration form for room '" + mucAddress + "' while having joined the room, but without being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner (that is not joined in the room) can request a room configuration form.
+     *
+     * This test implementation makes a second user join the room, to prevent the service from destroying the room after
+     * its last user left.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "a room owner requests a new configuration form [...] the service MUST send a configuration form to the room owner ")
+    public void testObtainRoomConfigOwnerNonJoined() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-owner-not-joined");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Make a second user join before the owner leaves the room. This prevents the service from reaping empty rooms during the test.
+            mucAsSeenByParticipant.join(nicknameParticipant);
+            mucAsSeenByOwner.leave();
+
+            final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+            requestConfigurationFormStanza.setTo(mucAddress);
+            requestConfigurationFormStanza.setType(IQ.Type.get);
+
+            try {
+                // Execute system under test.
+                conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to request a configuration form for '" + mucAddress + "' without being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            if (!mucAsSeenByOwner.isJoined()) {
+                mucAsSeenByOwner.join(nicknameOwner);
+            }
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner (that is joined in the room) can request a room configuration form.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "a room owner requests a new configuration form [...] the service MUST send a configuration form to the room owner")
+    public void testObtainRoomConfigOwnerJoined() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-owner-joined");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+            requestConfigurationFormStanza.setTo(mucAddress);
+            requestConfigurationFormStanza.setType(IQ.Type.get);
+
+            try {
+                // Execute system under test.
+                conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to request a configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a room configuration form contains the current options set as defaults.
+     *
+     * The implementation attempts to create a room with a configuration that matches any non-default option for
+     * list-single fields.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "a room owner requests a new configuration form [...] the service MUST send a configuration form to the room owner with the current options set as defaults")
+    public void testObtainRoomConfigHasCurrentOptionsAsDefaults() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-defaults");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        final Map<String, FormField.Value> optionValues = new HashMap<>();
+        try {
+            mucAsSeenByOwner.create(nicknameOwner);
+            final Form configForm = mucAsSeenByOwner.getConfigurationForm();
+            final FillableForm answerForm = configForm.getFillableForm();
+
+            for (final FormField field : configForm.getDataForm().getFields()) {
+                // Set any non-default value for list-single fields
+                if (field instanceof ListSingleFormField) {
+                    final List<FormField.Option> options = ((ListSingleFormField) field).getOptions();
+                    final FormField.Value defaultValue = ((ListSingleFormField) field).getRawValue();
+                    if (!options.isEmpty()) {
+                        for (final FormField.Option option : options) {
+                            if (!option.getValue().equals(defaultValue)) {
+                                optionValues.put(field.getFieldName(), option.getValue());
+                                answerForm.setAnswer(field.getFieldName(), option.getValue().getValue());
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (optionValues.isEmpty()) {
+                throw new TestNotPossibleException("Room configuration form does not contain any options that are usable by this test.");
+            }
+
+            try {
+                mucAsSeenByOwner.sendConfigurationForm(answerForm);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to create room with a semi-random pick of options for list-single fields.");
+            }
+
+            // Execute system under test.
+            final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+            requestConfigurationFormStanza.setTo(mucAddress);
+            requestConfigurationFormStanza.setType(IQ.Type.get);
+
+            try {
+                final IQ response = conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+
+                // Verify result.
+                final DataForm configurationForm = DataForm.from(response);
+                for (final Map.Entry<String, FormField.Value> entry : optionValues.entrySet()) {
+                    final String fieldName = entry.getKey();
+                    final FormField.Value expectedValue = entry.getValue();
+                    assertTrue(configurationForm.hasField(fieldName), "Expected the room configuration form requested by '" + conOne.getUser() + "' from '" + mucAddress + "' to contain a field named '" + fieldName + "' that was set to a non-default value when creating the room (but the configuration form does not contain that field).");
+                    assertEquals(expectedValue.getValue(), configurationForm.getField(fieldName).getFirstValue(), "Expected the default value for field '" + fieldName + "' in the room configuration form requested by '" + conOne.getUser() + "' from '" + mucAddress + "' to equal the value that was used when creating the room (but it does not).");
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to request a configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a cancelled room configuration form does not affect the room configuration.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.")
+    public void testRoomConfigCancel() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-cancel");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            final Form originalConfigForm = mucAsSeenByOwner.getConfigurationForm();
+            final List<FormField> originalConfig = originalConfigForm.getDataForm().getFields();
+
+            try {
+                // Execute system under test.
+                final MUCOwner cancelRequest = new MUCOwner();
+                cancelRequest.setTo(mucAddress);
+                cancelRequest.setType(IQ.Type.set);
+                cancelRequest.addExtension(DataForm.builder(DataForm.Type.cancel).build());
+
+                conOne.sendIqRequestAndWaitForResponse(cancelRequest);
+
+                // Verify result.
+                final List<FormField> laterConfig = mucAsSeenByOwner.getConfigurationForm().getDataForm().getFields();
+                assertArrayEquals(originalConfig.toArray(), laterConfig.toArray(), "Expected the room configuration for '" + mucAddress + "' to remain unchanged after cancelling a configuration form, but the list of form field taken before and after the form cancellation differs.");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to submit and/or cancel a configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO uncomment this after Smack is updated to get the new API used by this implementation (SMACK-947).
+//    /**
+//     * Verifies that when as a result of a change in the room configuration a room admin loses admin status while in the room, the room sends updated presence.
+//     */
+//    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a room admin loses admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+//    public void testRoomConfigDropAdmin() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-admin");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        try {
+//            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+//                .setRoomAdmins(Set.of(conOne.getUser().asBareJid(), conTwo.getUser().asBareJid()))
+//                .submitConfigurationForm();
+//
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        ownerSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            ownerSeesTarget.waitForResult(timeout);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
+//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void adminRevoked(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        ownerSeesRevoke.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+//                @Override
+//                public void adminRevoked() {
+//                    targetSeesRevoke.signal();
+//                }
+//            });
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void adminRevoked(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesRevoke.signal();
+//                    }
+//                }
+//            });
+//
+//            try {
+//                // Execute system under test.
+//                mucAsSeenByOwner.getConfigFormManager()
+//                    .setRoomAdmins(Set.of(conOne.getUser().asBareJid()))
+//                    .submitConfigurationForm();
+//
+//                // Verify result.
+//                assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//                assertResult(targetSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//                assertResult(participantSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//            } catch (XMPPException.XMPPErrorException e) {
+//                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+//            }
+//        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+//            throw new TestNotPossibleException(e);
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    // TODO uncomment this after Smack is updated to get the new API used by this implementation (SMACK-947).
+//    /**
+//     * Verifies that when as a result of a change in the room configuration a user gains admin status while in the room, the room sends updated presence.
+//     */
+//    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a user gains admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+//    public void testRoomConfigAddAdmin() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-admin");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        try {
+//            mucAsSeenByOwner.create(nicknameOwner).makeInstant();
+//
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        ownerSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            ownerSeesTarget.waitForResult(timeout);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
+//            final SimpleResultSyncPoint participantSeesGrant = new SimpleResultSyncPoint();
+//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void adminGranted(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        ownerSeesGrant.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+//                @Override
+//                public void adminGranted() {
+//                    targetSeesGrant.signal();
+//                }
+//            });
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void adminGranted(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesGrant.signal();
+//                    }
+//                }
+//            });
+//
+//            try {
+//                // Execute system under test.
+//                mucAsSeenByOwner.getConfigFormManager()
+//                    .setRoomAdmins(Set.of( conTwo.getUser().asBareJid()))
+//                    .submitConfigurationForm();
+//
+//                // Verify result.
+//                assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//                assertResult(targetSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//                assertResult(participantSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+//            } catch (XMPPException.XMPPErrorException e) {
+//                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+//            }
+//        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+//            throw new TestNotPossibleException(e);
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that when as a result of a change in the room configuration a room owner loses owner status while in the room, the room sends updated presence.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a room owner loses owner status while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+    public void testRoomConfigDropOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-owner");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+                .setRoomOwners(Set.of(conOne.getUser().asBareJid(), conTwo.getUser().asBareJid()))
+                .submitConfigurationForm();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipRevoked() {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesRevoke.signal();
+                    }
+                }
+            });
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setRoomOwners(Set.of(conOne.getUser().asBareJid()))
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of ownership from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+                assertResult(targetSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of ownership from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+                assertResult(participantSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of ownership from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO uncomment after Smack provides a way to unset a form field (SMACK-946)
+//    /**
+//     * Verifies that a room configuration form cannot be used to remove the only owner of a room.
+//     */
+//    @SmackIntegrationTest(section = "10.2", quote = "A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a <conflict/> error to the owner.")
+//    public void testRoomConfigRemoveLastOwner() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-remove-last");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//
+//        try {
+//            createMuc(mucAsSeenByOwner, nicknameOwner);
+//
+//            // Execute system under test & Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                mucAsSeenByOwner.getConfigFormManager()
+//                    .setRoomOwners(new HashSet<>())
+//                    .submitConfigurationForm();
+//            }, "Expected an error after '" + conOne.getUser() + "' (that is the only room owner) tried to update the configuration of room '" + mucAddress + "' to remove itself as an owner (but none occurred).");
+//            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to remove itself as owner of room '" + mucAddress + "' using the room configuration form.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that when as a result of a change in the room configuration a user gains owner status while in the room, the room sends updated presence.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a user gains owner status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+    public void testRoomConfigAddOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-owner");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).makeInstant();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesGrant = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipGranted() {
+                    targetSeesGrant.signal();
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesGrant.signal();
+                    }
+                }
+            });
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setRoomOwners(Set.of(conOne.getUser().asBareJid(), conTwo.getUser().asBareJid()))
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of ownership to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+                assertResult(targetSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of ownership to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+                assertResult(participantSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of ownership to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room owner (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that when as a result of a change in the room configuration a room becomes members-only, all non-members get removed from the room.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.")
+    public void testRoomConfigToMemberOnly() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-make-memberonly");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByMember = mucManagerThree.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameMember = Resourcepart.from("member-" + randomString);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        final SimpleResultSyncPoint ownerSeesRemoval = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint targetSeesRemoval = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint memberSeesRemoval = new SimpleResultSyncPoint();
+        final StanzaListener ownerListener = stanza -> ownerSeesRemoval.signal();
+        final StanzaListener targetListener = stanza -> targetSeesRemoval.signal();
+        final StanzaListener memberListener = stanza -> memberSeesRemoval.signal();
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+                .setMembersOnly(false)
+                .submitConfigurationForm();
+
+            mucAsSeenByOwner.grantMembership(conThree.getUser());
+
+            mucAsSeenByMember.join(nicknameMember);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint memberSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByMember.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        memberSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTarget.waitForResult(timeout);
+            memberSeesTarget.waitForResult(timeout);
+
+            final StanzaFilter removalDetectionFilter = new AndFilter(
+                FromMatchesFilter.create(mucAddress),
+                StanzaTypeFilter.PRESENCE,
+                FromMatchesFilter.createFull(targetMucAddress),
+                new MUCUserStatusCodeFilter(MUCUser.Status.create(322))
+            );
+            conOne.addStanzaListener(ownerListener, removalDetectionFilter);
+            conTwo.addStanzaListener(targetListener, removalDetectionFilter);
+            conThree.addStanzaListener(memberListener, removalDetectionFilter);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setMembersOnly(true)
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesRemoval, "Expected '" + conOne.getUser() + "' to receive an 'unavailable' presence stanza with status code 322 from '" + targetMucAddress + "' indicating that non-member '" + targetMucAddress + "' was removed from the room, after '" + conOne.getUser() + " updated the room configuration to be members-only (but no such stanza was received).");
+                assertResult(targetSeesRemoval, "Expected '" + conTwo.getUser() + "' to receive an 'unavailable' presence stanza with status code 322 from '" + targetMucAddress + "' indicating that non-member '" + targetMucAddress + "' was removed from the room, after '" + conOne.getUser() + " updated the room configuration to be members-only (but no such stanza was received).");
+                assertResult(memberSeesRemoval, "Expected '" + conThree.getUser() + "' to receive an 'unavailable' presence stanza with status code 322 from '" + targetMucAddress + "' indicating that non-member '" + targetMucAddress + "' was removed from the room, after '" + conOne.getUser() + " updated the room configuration to be members-only (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+            conOne.removeStanzaListener(ownerListener);
+            conTwo.removeStanzaListener(targetListener);
+            conThree.removeStanzaListener(memberListener);
+        }
+    }
+
+    /**
+     * Verifies that a 170 notification is broadcast after room logging is enabled.
+     */
+    @SmackIntegrationTest(section = "10.2.1", quote = "A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. [...] which shall contain only a <status/> element with an appropriate value for the 'code' attribute. [...] If room logging is now enabled, status code 170.")
+    public void testRoomConfigNotification170() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-170");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final SimpleResultSyncPoint ownerSeesNotification = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint participantSeesNotification = new SimpleResultSyncPoint();
+        final StanzaListener ownerListener = stanza -> ownerSeesNotification.signal();
+        final StanzaListener participantListener = stanza -> participantSeesNotification.signal();
+        final int statusCode = 170;
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+                .disablPublicLogging()
+                .submitConfigurationForm();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final StanzaFilter notificationDetectionFilter = new AndFilter(
+                FromMatchesFilter.create(mucAddress),
+                StanzaTypeFilter.MESSAGE,
+                new MUCUserStatusCodeFilter(MUCUser.Status.create(statusCode))
+            );
+            conOne.addStanzaListener(ownerListener, notificationDetectionFilter);
+            conTwo.addStanzaListener(participantListener, notificationDetectionFilter);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .enablePublicLogging()
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesNotification, "Expected '" + conOne.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to enable room logging (but no such stanza was received).");
+                assertResult(participantSeesNotification, "Expected '" + conTwo.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to enable room logging (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+            conOne.removeStanzaListener(ownerListener);
+            conTwo.removeStanzaListener(participantListener);
+        }
+    }
+
+    /**
+     * Verifies that a 171 notification is broadcast after room logging is disabled.
+     */
+    @SmackIntegrationTest(section = "10.2.1", quote = "A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. [...] which shall contain only a <status/> element with an appropriate value for the 'code' attribute. [...] If room logging is now disabled, status code 171.")
+    public void testRoomConfigNotification171() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-171");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final SimpleResultSyncPoint ownerSeesNotification = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint participantSeesNotification = new SimpleResultSyncPoint();
+        final StanzaListener ownerListener = stanza -> ownerSeesNotification.signal();
+        final StanzaListener participantListener = stanza -> participantSeesNotification.signal();
+        final int statusCode = 171;
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+                .enablePublicLogging()
+                .submitConfigurationForm();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final StanzaFilter notificationDetectionFilter = new AndFilter(
+                FromMatchesFilter.create(mucAddress),
+                StanzaTypeFilter.MESSAGE,
+                new MUCUserStatusCodeFilter(MUCUser.Status.create(statusCode))
+            );
+            conOne.addStanzaListener(ownerListener, notificationDetectionFilter);
+            conTwo.addStanzaListener(participantListener, notificationDetectionFilter);
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .disablPublicLogging()
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesNotification, "Expected '" + conOne.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to disable room logging (but no such stanza was received).");
+                assertResult(participantSeesNotification, "Expected '" + conTwo.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to disable room logging (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+            conOne.removeStanzaListener(ownerListener);
+            conTwo.removeStanzaListener(participantListener);
+        }
+    }
+
+    /**
+     * Verifies that a 172 notification is broadcast after the room is switched to be non-anonymous.
+     */
+    @SmackIntegrationTest(section = "10.2.1", quote = "A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. [...] which shall contain only a <status/> element with an appropriate value for the 'code' attribute. [...] If the room is now non-anonymous, status code 172.")
+    public void testRoomConfigNotification172() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-172");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final SimpleResultSyncPoint ownerSeesNotification = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint participantSeesNotification = new SimpleResultSyncPoint();
+        final StanzaListener ownerListener = stanza -> ownerSeesNotification.signal();
+        final StanzaListener participantListener = stanza -> participantSeesNotification.signal();
+        final int statusCode = 172;
+        try {
+            createSemiAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final StanzaFilter notificationDetectionFilter = new AndFilter(
+                FromMatchesFilter.create(mucAddress),
+                StanzaTypeFilter.MESSAGE,
+                new MUCUserStatusCodeFilter(MUCUser.Status.create(statusCode))
+            );
+            conOne.addStanzaListener(ownerListener, notificationDetectionFilter);
+            conTwo.addStanzaListener(participantListener, notificationDetectionFilter);
+
+            try {
+                // Execute system under test.
+                final Form configForm = mucAsSeenByOwner.getConfigurationForm();
+                final FillableForm answerForm = configForm.getFillableForm();
+                answerForm.setAnswer("muc#roomconfig_whois", "anyone");
+                mucAsSeenByOwner.sendConfigurationForm(answerForm);
+
+                // Verify result.
+                assertResult(ownerSeesNotification, "Expected '" + conOne.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to be non-anonymous (but no such stanza was received).");
+                assertResult(participantSeesNotification, "Expected '" + conTwo.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to be non-anonymous (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+            conOne.removeStanzaListener(ownerListener);
+            conTwo.removeStanzaListener(participantListener);
+        }
+    }
+
+    /**
+     * Verifies that a 173 notification is broadcast after the room is switched to be semi-anonymous.
+     */
+    @SmackIntegrationTest(section = "10.2.1", quote = "A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. [...] which shall contain only a <status/> element with an appropriate value for the 'code' attribute. [...] f the room is now semi-anonymous, status code 173.")
+    public void testRoomConfigNotification173() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-173");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final SimpleResultSyncPoint ownerSeesNotification = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint participantSeesNotification = new SimpleResultSyncPoint();
+        final StanzaListener ownerListener = stanza -> ownerSeesNotification.signal();
+        final StanzaListener participantListener = stanza -> participantSeesNotification.signal();
+        final int statusCode = 173;
+        try {
+            createNonAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final StanzaFilter notificationDetectionFilter = new AndFilter(
+                FromMatchesFilter.create(mucAddress),
+                StanzaTypeFilter.MESSAGE,
+                new MUCUserStatusCodeFilter(MUCUser.Status.create(statusCode))
+            );
+            conOne.addStanzaListener(ownerListener, notificationDetectionFilter);
+            conTwo.addStanzaListener(participantListener, notificationDetectionFilter);
+
+            try {
+                // Execute system under test.
+                final Form configForm = mucAsSeenByOwner.getConfigurationForm();
+                final FillableForm answerForm = configForm.getFillableForm();
+                answerForm.setAnswer("muc#roomconfig_whois", "moderators");
+                mucAsSeenByOwner.sendConfigurationForm(answerForm);
+
+                // Verify result.
+                assertResult(ownerSeesNotification, "Expected '" + conOne.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to be semi-anonymous (but no such stanza was received).");
+                assertResult(participantSeesNotification, "Expected '" + conTwo.getUser() + "' to receive an a message stanza notification with status code " + statusCode + " from '" + mucAddress + "'  after '" + conOne.getUser() + " updated the room configuration to be semi-anonymous (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+            conOne.removeStanzaListener(ownerListener);
+            conTwo.removeStanzaListener(participantListener);
+        }
+    }
+
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -239,6 +239,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
                             if (!option.getValue().equals(defaultValue)) {
                                 optionValues.put(field.getFieldName(), option.getValue());
                                 answerForm.setAnswer(field.getFieldName(), option.getValue().getValue());
+                                break;
                             }
                         }
                     }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -740,7 +740,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
                 .setMembersOnly(false)
                 .submitConfigurationForm();
 
-            mucAsSeenByOwner.grantMembership(conThree.getUser());
+            mucAsSeenByOwner.grantMembership(conThree.getUser().asBareJid());
 
             mucAsSeenByMember.join(nicknameMember);
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -43,10 +43,7 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -320,191 +317,189 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
         }
     }
 
-    // TODO uncomment this after Smack is updated to get the new API used by this implementation (SMACK-947).
-//    /**
-//     * Verifies that when as a result of a change in the room configuration a room admin loses admin status while in the room, the room sends updated presence.
-//     */
-//    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a room admin loses admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
-//    public void testRoomConfigDropAdmin() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-admin");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        try {
-//            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
-//                .setRoomAdmins(Set.of(conOne.getUser().asBareJid(), conTwo.getUser().asBareJid()))
-//                .submitConfigurationForm();
-//
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        ownerSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            ownerSeesTarget.waitForResult(timeout);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
-//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void adminRevoked(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        ownerSeesRevoke.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
-//                @Override
-//                public void adminRevoked() {
-//                    targetSeesRevoke.signal();
-//                }
-//            });
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void adminRevoked(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesRevoke.signal();
-//                    }
-//                }
-//            });
-//
-//            try {
-//                // Execute system under test.
-//                mucAsSeenByOwner.getConfigFormManager()
-//                    .setRoomAdmins(Set.of(conOne.getUser().asBareJid()))
-//                    .submitConfigurationForm();
-//
-//                // Verify result.
-//                assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//                assertResult(targetSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//                assertResult(participantSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//            } catch (XMPPException.XMPPErrorException e) {
-//                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
-//            }
-//        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
-//            throw new TestNotPossibleException(e);
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that when as a result of a change in the room configuration a room admin loses admin status while in the room, the room sends updated presence.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a room admin loses admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+    public void testRoomConfigDropAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-admin");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
 
-    // TODO uncomment this after Smack is updated to get the new API used by this implementation (SMACK-947).
-//    /**
-//     * Verifies that when as a result of a change in the room configuration a user gains admin status while in the room, the room sends updated presence.
-//     */
-//    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a user gains admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
-//    public void testRoomConfigAddAdmin() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-admin");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        try {
-//            mucAsSeenByOwner.create(nicknameOwner).makeInstant();
-//
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        ownerSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            ownerSeesTarget.waitForResult(timeout);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
-//            final SimpleResultSyncPoint participantSeesGrant = new SimpleResultSyncPoint();
-//            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void adminGranted(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        ownerSeesGrant.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
-//                @Override
-//                public void adminGranted() {
-//                    targetSeesGrant.signal();
-//                }
-//            });
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void adminGranted(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesGrant.signal();
-//                    }
-//                }
-//            });
-//
-//            try {
-//                // Execute system under test.
-//                mucAsSeenByOwner.getConfigFormManager()
-//                    .setRoomAdmins(Set.of( conTwo.getUser().asBareJid()))
-//                    .submitConfigurationForm();
-//
-//                // Verify result.
-//                assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//                assertResult(targetSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//                assertResult(participantSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
-//            } catch (XMPPException.XMPPErrorException e) {
-//                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
-//            }
-//        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
-//            throw new TestNotPossibleException(e);
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).getConfigFormManager()
+                .setRoomAdmins(Set.of(conTwo.getUser().asBareJid()))
+                .submitConfigurationForm();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminRevoked() {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesRevoke.signal();
+                    }
+                }
+            });
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setRoomAdmins(Set.of()) // Remove the admin.
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+                assertResult(targetSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+                assertResult(participantSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status from '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to remove '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that when as a result of a change in the room configuration a user gains admin status while in the room, the room sends updated presence.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "If as a result of a change in the room configuration a user gains admin status while in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status [...]")
+    public void testRoomConfigAddAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-admin");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        try {
+            mucAsSeenByOwner.create(nicknameOwner).makeInstant();
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesGrant = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminGranted() {
+                    targetSeesGrant.signal();
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesGrant.signal();
+                    }
+                }
+            });
+
+            try {
+                // Execute system under test.
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setRoomAdmins(Set.of( conTwo.getUser().asBareJid()))
+                    .submitConfigurationForm();
+
+                // Verify result.
+                assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+                assertResult(targetSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+                assertResult(participantSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status to '" + targetMucAddress + "', after '" + conOne.getUser() + " updated the room configuration to add '" + conTwo.getUser() + "' as a room admin (but no such stanza was received).");
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to apply a change to a room using its configuration form for '" + mucAddress + "' while being in the room (but the server returned an error).", e);
+            }
+        } catch (MultiUserChatException.MucConfigurationNotSupportedException e) {
+            throw new TestNotPossibleException(e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that when as a result of a change in the room configuration a room owner loses owner status while in the room, the room sends updated presence.
@@ -599,33 +594,32 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
         }
     }
 
-    // TODO uncomment after Smack provides a way to unset a form field (SMACK-946)
-//    /**
-//     * Verifies that a room configuration form cannot be used to remove the only owner of a room.
-//     */
-//    @SmackIntegrationTest(section = "10.2", quote = "A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a <conflict/> error to the owner.")
-//    public void testRoomConfigRemoveLastOwner() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-remove-last");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//
-//        try {
-//            createMuc(mucAsSeenByOwner, nicknameOwner);
-//
-//            // Execute system under test & Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                mucAsSeenByOwner.getConfigFormManager()
-//                    .setRoomOwners(new HashSet<>())
-//                    .submitConfigurationForm();
-//            }, "Expected an error after '" + conOne.getUser() + "' (that is the only room owner) tried to update the configuration of room '" + mucAddress + "' to remove itself as an owner (but none occurred).");
-//            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to remove itself as owner of room '" + mucAddress + "' using the room configuration form.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that a room configuration form cannot be used to remove the only owner of a room.
+     */
+    @SmackIntegrationTest(section = "10.2", quote = "A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a <conflict/> error to the owner.")
+    public void testRoomConfigRemoveLastOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-remove-last");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Execute system under test & Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                mucAsSeenByOwner.getConfigFormManager()
+                    .setRoomOwners(new HashSet<>())
+                    .submitConfigurationForm();
+            }, "Expected an error after '" + conOne.getUser() + "' (that is the only room owner) tried to update the configuration of room '" + mucAddress + "' to remove itself as an owner (but none occurred).");
+            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to remove itself as owner of room '" + mucAddress + "' using the room configuration form.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that when as a result of a change in the room configuration a user gains owner status while in the room, the room sends updated presence.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
@@ -1,0 +1,547 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.StanzaCollector;
+import org.jivesoftware.smack.StanzaListener;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.filter.*;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.Presence;
+import org.jivesoftware.smack.packet.StanzaBuilder;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCInitialPresence;
+import org.jivesoftware.smackx.muc.packet.MUCOwner;
+import org.jivesoftware.smackx.muc.packet.MUCUser;
+import org.jivesoftware.smackx.xdata.FormField;
+import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.packet.DataForm;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.List;
+import java.util.logging.Level;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.1 Owner Use Cases: Creating a Room" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#createroom">XEP-0045 Section 10.1</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerCreateRoomIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that a newly created room is locked.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "The user sends presence to <room@service/nick> [...] the service MUST create the room [...] not allow anyone else to enter the room (effectively \"locking\" the room)")
+    public void testRoomLockedWhenCreated() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-locked-when-created");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+                .to(ownerMucAddress)
+                .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+                .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        // Execute system under test.
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> mucAsSeenByParticipant.join(nicknameParticipant), "Expected an error to be returned to '" + conTwo.getUser() + "' when they tried to join room '" + mucAddress + "' that should currently be 'locked' (but no error was returned).");
+            assertEquals(StanzaError.Condition.item_not_found, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in (expected) error that was returned to '" + conTwo.getUser() + "' when they tried to join room '" + mucAddress + "' that should currently be 'locked'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a newly created room is responded to by an acknowledgement that the room has been created.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "The user sends presence to <room@service/nick> [...] The initial presence stanza received by the owner from the room MUST include extended presence information [...] acknowledging that the room has been created (via status code 201) and is awaiting configuration.")
+    public void testRoomResponseIndicatesAcknowledgement() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-response-indicates-acknowledgement");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        // Execute system under test.
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            final Presence response = collector.nextResult();
+
+            // Verify result.
+            final MUCUser extension = response.getExtension(MUCUser.class);
+            assertNotNull(extension, "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to include extended presence information (but it does not).");
+            assertTrue(extension.getStatus().contains(MUCUser.Status.ROOM_CREATED_201), "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to acknowledge that the room has been created by including the '201' status code (but it does not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a newly created room is owned by the requesting user.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "The user sends presence to <room@service/nick> [...] The initial presence stanza received by the owner from the room MUST include extended presence information indicating the user's status as an owner [...]")
+    public void testRoomResponseIndicatesCreatorIsOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-response-indicates-creator-is-owner");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        // Execute system under test.
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            final Presence response = collector.nextResult();
+
+            // Verify result.
+            final MUCUser extension = response.getExtension(MUCUser.class);
+            assertNotNull(extension, "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to include extended presence information (but it does not).");
+            assertTrue(extension.getStatus().contains(MUCUser.Status.PRESENCE_TO_SELF_110), "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to indicate the user's status as 'owner' by including the '110' status code (but it does not).");
+            assertNotNull(extension.getItem(), "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to include extended presence information that contains an item (but no item was found).");
+            assertEquals(MUCAffiliation.owner, extension.getItem().getAffiliation(), "Expected the initial presence returned by '" + mucAddress + "' to owner '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to indicate the user's status as 'owner' by including the 'owner' affiliation (but it does not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a newly created room returns a configuration form response when requested.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "If the room owner requested a configuration form, the service MUST send an IQ result to the room owner")
+    public void testRoomConfigurationFormRequest() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-conf-form");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            // Execute system under test.
+            final IQ response = conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+
+            // Verify result.
+            assertTrue(response instanceof MUCOwner || response.hasExtension(MUCOwner.ELEMENT, MUCOwner.NAMESPACE), "Expected the response with stanza ID '" + response.getStanzaId() + "' from '" + mucAddress + "' to the request for a configuration form from '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to be a stanza that includes a child element named '" + MUCOwner.ELEMENT + "' qualified by the namespace '" + MUCOwner.NAMESPACE + "' (but it does not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a newly created room returns a configuration form with options, or no form at all, when requested.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "If the room owner requested a configuration form, the service MUST send an IQ result to the room owner containing a configuration form qualified by the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.")
+    public void testRoomConfigurationFormResponse() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-conf-form-response");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            // Execute system under test.
+            final IQ response = conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+            final DataForm form = response.getExtension(DataForm.class);
+
+            // Verify result (a null form is a valid response!)
+            boolean hasConfigurationOptions = false;
+            if (form != null) {
+                hasConfigurationOptions = form.getFields().stream().anyMatch(formField -> !List.of(FormField.Type.hidden, FormField.Type.fixed).contains(formField.getType()));
+            }
+            assertTrue(form == null || hasConfigurationOptions, "Expected the response with stanza ID '" + response.getStanzaId() + "' from '" + mucAddress + "' to the request for a configuration form from '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to either contain no configuration form, or a form that includes one or more configuration options. The form that was returned has no configuration options.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that submitting a form unlocks a previously locked room.
+     *
+     * This test attempts to fill out a retrieved configuration form, and submit that. As the provided data is hard-coded,
+     * the service might reject this. This test will throw TestNotPossible if the room creation fails, and asserts only
+     * that once a configuration form was successfully submitted, another user can join the room (thus proving that it
+     * is 'unlocked').
+     * 
+     * @see #testRoomRequestInitialConfigForm()
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "Once the service receives the completed configuration form from the initial room owner [...], the service MUST \"unlock\" the room (i.e., allow other users to enter the room) and send an IQ of type \"result\" to the room owner.")
+    public void testRoomConfigurationUnlocksRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-unlocks");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+            final IQ response = conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+            final DataForm form = response.getExtension(DataForm.class);
+            if (form == null) {
+                // If this happens, #testRoomRequestInitialConfigForm() will have failed.
+                throw new TestNotPossibleException("MUC service does not offer configuration options.");
+            }
+
+            // Execute system under test.
+            final DataForm dataFormToSubmit;
+            final FillableForm fillableForm = new FillableForm(form);
+            try {
+                form.getFields().stream() // Attempt to formulate an answer.
+                    .filter(FormField::isRequired)
+                    .forEach(formField -> {
+                        switch (formField.getType()) {
+                            case bool:
+                                fillableForm.setAnswer(formField.getFieldName(), false);
+                                return;
+                            case jid_multi:
+                            case jid_single:
+                                fillableForm.setAnswer(formField.getFieldName(), JidCreate.bareFromOrThrowUnchecked("test@example.org"));
+                                return;
+
+                            case text_single:
+                            case text_multi:
+                            case text_private:
+                                fillableForm.setAnswer(formField.getFieldName(), "integration test");
+                        }
+                    });
+
+                dataFormToSubmit = fillableForm.getDataFormToSubmit();
+            } catch (Throwable t) {
+                // This is a test implementation failure, not a failure of the system under test.
+                LOGGER.log(Level.WARNING, "Test implementation failure: unable to provide answers to required configuration options", t);
+                throw new TestNotPossibleException("Test implementation failure: unable to provide answers to required configuration options: " + t.getMessage());
+            }
+
+            final MUCOwner unlockRequest = new MUCOwner();
+            unlockRequest.setTo(mucAddress);
+            unlockRequest.setType(IQ.Type.set);
+            unlockRequest.addExtension(dataFormToSubmit);
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(unlockRequest);
+            } catch (XMPPException.XMPPErrorException e) {
+                // This is (likely) a test implementation failure, not a failure of the system under test.
+                LOGGER.log(Level.WARNING, "Test implementation failure: unable to provide answers acceptable to service to create MUC room", e);
+                throw new TestNotPossibleException("Test implementation failure: unable to provide answers acceptable to service to create MUC room: " + e.getMessage());
+            }
+
+            // Verify result
+            try {
+                mucAsSeenByParticipant.join(nicknameParticipant);
+            } catch (XMPPException.XMPPErrorException e) {
+                if (StanzaError.Condition.item_not_found.equals(e.getStanzaError().getCondition())) {
+                    fail("Expected '" + mucAddress + "' to be unlocked after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') successfully submitted a configuration form, but '" + conTwo.getUser()+ "' (using nickname '" + nicknameParticipant + "') cannot join the room.");
+                }
+                throw e;
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that creating an instant room yields a 'result' IQ response.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "Once the service [...] or receives a request for an instant room [...] the service [...] send an IQ of type \"result\" to the room owner.")
+    public void testRoomRequestInstantRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-instant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            // Execute system under test.
+            final MUCOwner instantRoomRequest = new MUCOwner();
+            instantRoomRequest.setTo(mucAddress);
+            instantRoomRequest.setType(IQ.Type.set);
+            instantRoomRequest.addExtension(DataForm.builder().build());
+
+            IQ response = null;
+            try {
+                response = conOne.sendIqRequestAndWaitForResponse(instantRoomRequest);
+            } catch (XMPPException.XMPPErrorException e) {
+                // Verify result
+                fail("Expected '" + mucAddress + "' to receive an IQ response of type 'result' after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') requested an instant room to be created, but an error was returned instead: " + e.getStanzaError());
+            }
+            assertEquals(IQ.Type.result, response.getType(), "Expected '" + mucAddress + "' to receive an IQ response of type 'result' after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') requested an instant room to be created (but another type was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that cancelling a room configuration destroys a room.
+     */
+    @SmackIntegrationTest(section = "10.1.1", quote = "Once the service receives the completed configuration form [...] If the service receives a cancellation, it MUST destroy the room.")
+    public void testRoomConfigCancelDestroysRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-cancel-destroys");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            // Execute system under test.
+            final MUCOwner cancelRequest = new MUCOwner();
+            cancelRequest.setTo(mucAddress);
+            cancelRequest.setType(IQ.Type.set);
+            cancelRequest.addExtension(DataForm.builder(DataForm.Type.cancel).build());
+
+            final SimpleResultSyncPoint ownerSeesDestruction = new SimpleResultSyncPoint();
+            final StanzaListener destructionListener = stanza -> { if (MUCUser.from(stanza).getDestroy() != null) { ownerSeesDestruction.signal(); } };
+            final StanzaFilter destructionFilter = new AndFilter(PresenceTypeFilter.UNAVAILABLE, FromMatchesFilter.create(ownerMucAddress), new ExtensionElementFilter<>(MUCUser.class));
+            conOne.addAsyncStanzaListener(destructionListener, destructionFilter);
+
+            conOne.sendStanza(cancelRequest);
+
+            // Verify result
+            assertResult(ownerSeesDestruction, "Expected '" + mucAddress + "' to be destroyed after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') cancelled the configuration of the room, but no destruction stanza was received by the user.");
+        } catch (Throwable t) { // Only tear down on a failure, as the MUC will otherwise already have been destroyed!
+            // Tear down test fixture.
+            try {
+                tryDestroy(mucAsSeenByOwner);
+            } catch (XMPPException.XMPPErrorException e) {
+                LOGGER.warning("Error returned while destroying room that should already be destroyed in the course of the test: " + e.getStanzaError());
+            }
+            throw t;
+        }
+    }
+
+    /**
+     * Verifies that creating an instant room unlocks a previously locked room.
+     *
+     * @see #testRoomRequestInstantRoom()
+     */
+    @SmackIntegrationTest(section = "10.1.2", quote = "If the initial room owner wants to accept the default room configuration (i.e., create an \"instant room\") [...] by sending an IQ set [...] The service MUST then unlock the room and allow other entities to join it.")
+    public void testRoomRequestInstantUnlocksRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-instant-unlocks");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+
+            final MUCOwner instantRoomRequest = new MUCOwner();
+            instantRoomRequest.setTo(mucAddress);
+            instantRoomRequest.setType(IQ.Type.set);
+            instantRoomRequest.addExtension(DataForm.builder().build());
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(instantRoomRequest);
+            } catch (XMPPException.XMPPErrorException e) {
+                // If this happens, #testRoomRequestInstantRoom() will have failed.
+                throw new TestNotPossibleException("Unable to create a room. Expected '" + mucAddress + "' to be created after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') requested an instant room to be created, but an error was returned instead: " + e.getStanzaError());
+            }
+
+            // Execute system under test.
+            try {
+                mucAsSeenByParticipant.join(nicknameParticipant);
+            } catch (XMPPException.XMPPErrorException e) {
+                // Verify result
+                if (StanzaError.Condition.item_not_found.equals(e.getStanzaError().getCondition())) {
+                    fail("Expected '" + mucAddress + "' to be unlocked after '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') requested an instant room to be created, but '" + conTwo.getUser()+ "' (using nickname '" + nicknameParticipant + "') cannot join the room.");
+                }
+                throw e;
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that requesting an initial configuration form causes the service the return a (possibly empty) initial
+     * room configuration form.
+     */
+    @SmackIntegrationTest(section = "10.1.3", quote = "If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form [...] the service MUST return an initial room configuration form to the user.")
+    public void testRoomRequestInitialConfigForm() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-get-config");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        final Presence createMucStanza = StanzaBuilder.buildPresence()
+            .to(ownerMucAddress)
+            .addExtension(new MUCInitialPresence(null, 0, 0, 0, null))
+            .build();
+
+        final StanzaFilter responseFilter = new AndFilter(StanzaTypeFilter.PRESENCE, new FromMatchesFilter(ownerMucAddress, true));
+
+        final MUCOwner requestConfigurationFormStanza = new MUCOwner();
+        requestConfigurationFormStanza.setTo(mucAddress);
+        requestConfigurationFormStanza.setType(IQ.Type.get);
+
+        // Execute system under test.
+        try (final StanzaCollector collector = conOne.createStanzaCollectorAndSend(responseFilter, createMucStanza)) {
+            collector.nextResult();
+            final IQ response = conOne.sendIqRequestAndWaitForResponse(requestConfigurationFormStanza);
+
+            // Verify result
+            final DataForm form = response.getExtension(DataForm.class);
+            assertNotNull(form, "Expected '" + conOne.getUser() + "' (MUC address '" + ownerMucAddress + "') to receive a (possibly empty) initial configuration form after requesting one from '" + mucAddress + "' (but none was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -189,43 +189,42 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
         }
     }
 
-// TODO enable this once SMACK-950 gets fixed.
-//    /**
-//     * Verifies that a room destruction request can contain an alternate venue and alternate venue password.
-//     */
-//    @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a <password/> child element of the <destroy/> element.")
-//    public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenuepassword");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        try {
-//            createMuc(mucAsSeenByOwner, nicknameOwner);
-//
-//            // Execute system under test.
-//            final MUCOwner request = new MUCOwner();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.setDestroy(new Destroy(JidCreate.entityBareFrom("alternate@muc.example.org"), "secret", null));
-//            try {
-//                conOne.sendIqRequestAndWaitForResponse(request);
-//
-//                // Verify result.
-//            } catch (XMPPException.XMPPErrorException e) {
-//                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy room '" + mucAddress + "' while providing an alternative venue and password (but the server returned an error).", e);
-//            }
-//        } finally {
-//            // Tear down test fixture.
-//            try {
-//                if (mucAsSeenByOwner.isJoined()) {
-//                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
-//                }
-//            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
-//                // Room was likely already destroyed.
-//            }
-//        }
-//    }
+    /**
+     * Verifies that a room destruction request can contain an alternate venue and alternate venue password.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a <password/> child element of the <destroy/> element.")
+    public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenuepassword");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(JidCreate.entityBareFrom("alternate@muc.example.org"), "secret", null));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy room '" + mucAddress + "' while providing an alternative venue and password (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
 
     /**
      * Verifies that a room destruction request can contain a reason.
@@ -282,13 +281,13 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
         final SimpleResultSyncPoint participantSeesDestroy = new SimpleResultSyncPoint();
         final UserStatusListener ownerListener = new UserStatusListener() {
             @Override
-            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+            public void roomDestroyed(MultiUserChat alternateMUC, String password, String reason) {
                 ownerSeesDestroy.signal();
             }
         };
         final UserStatusListener participantListener = new UserStatusListener() {
             @Override
-            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+            public void roomDestroyed(MultiUserChat alternateMUC, String password, String reason) {
                 participantSeesDestroy.signal();
             }
         };
@@ -339,21 +338,21 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
         final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
 
         final EntityBareJid alternateVenue = JidCreate.entityBareFrom("alternate@muc.example.org");
-        final String password = "secret"; // TODO use this after SMACK-950 gets resolved.
+        final String password = "secret";
         final String reason = "Destroying room as part of an integration test";
 
         final ResultSyncPoint<Destroy, Exception> ownerSeesDestroy = new ResultSyncPoint<>();
         final ResultSyncPoint<Destroy, Exception> participantSeesDestroy = new ResultSyncPoint<>();
         final UserStatusListener ownerListener = new UserStatusListener() {
             @Override
-            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
-                ownerSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), reason));
+            public void roomDestroyed(MultiUserChat alternateMUC, String password, String reason) {
+                ownerSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), password, reason));
             }
         };
         final UserStatusListener participantListener = new UserStatusListener() {
             @Override
-            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
-                participantSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), reason));
+            public void roomDestroyed(MultiUserChat alternateMUC, String password, String reason) {
+                participantSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), password, reason));
             }
         };
         mucAsSeenByOwner.addUserStatusListener(ownerListener);
@@ -366,18 +365,18 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
             final MUCOwner request = new MUCOwner();
             request.setTo(mucAddress);
             request.setType(IQ.Type.set);
-            request.setDestroy(new Destroy(alternateVenue, reason));
+            request.setDestroy(new Destroy(alternateVenue, password, reason));
 
             conOne.sendIqRequestAndWaitForResponse(request);
 
             // Verify result.
             final Destroy ownerDestroy = assertResult(ownerSeesDestroy, "Expected owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
             assertEquals(alternateVenue, ownerDestroy.getJid(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the alternate venue address that was provided in the destruction request (but that was found in the received presence).");
-            // TODO enable this after SMACK-950 gets resolved // assertEquals(password, ownerDestroy.getPassword(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
+            assertEquals(password, ownerDestroy.getPassword(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
             assertEquals(reason, ownerDestroy.getReason(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the reason that was provided in the destruction request (but that was found in the received presence).");
             final Destroy participantDestroy = assertResult(participantSeesDestroy, "Expected participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
             assertEquals(alternateVenue, participantDestroy.getJid(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the alternate venue address that was provided in the destruction request (but that was found in the received presence).");
-            // TODO enable this after SMACK-950 gets resolved // assertEquals(password, participantDestroy.getPassword(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
+            assertEquals(password, participantDestroy.getPassword(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
             assertEquals(reason, participantDestroy.getReason(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the reason that was provided in the destruction request (but that was found in the received presence).");
         } finally {
             // Tear down test fixture.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -156,7 +156,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * Verifies that a room destruction request can contain an alternate venue.
      */
     @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute.")
-    public void testAlternateVenue() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    public void testAlternateVenue() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenue");
@@ -193,7 +193,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * Verifies that a room destruction request can contain an alternate venue and alternate venue password.
      */
     @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a <password/> child element of the <destroy/> element.")
-    public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenuepassword");
@@ -230,7 +230,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * Verifies that a room destruction request can contain a reason.
      */
     @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The reason for the room destruction MAY be provided as the XML character data of a <reason/> child element of the <destroy/> element.")
-    public void testReason() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    public void testReason() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-reason");
@@ -267,7 +267,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * Verifies that a room destruction request causes all occupants to be removed.
      */
     @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room.")
-    public void testPresence() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    public void testPresence() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TimeoutException
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presence");
@@ -327,7 +327,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * all optional data.
      */
     @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.")
-    public void testPresenceOptional() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    public void testPresenceOptional() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TimeoutException
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presenceext");
@@ -393,13 +393,147 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     }
 
     /**
-     * Verifies that a room destruction request cannot be issued by a non-owner.
+     * Verifies that a room destruction request cannot be issued by a non-owner (but an admin).
      */
     @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
-    public void testAuthorization() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    public void testAuthorizationAdmin() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth");
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-admin");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            try {
+                mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (joined as '" + nicknameAdmin + "', an admin, not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (joined as '" + nicknameAdmin + "', an admin, not a room owner) tried to destroy room '" + mucAddress);
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request cannot be issued by a non-owner (but a member).
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testAuthorizationMember() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, MultiUserChatException.MucConfigurationNotSupportedException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-member");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameMember = Resourcepart.from("member-" + randomString);
+
+        try {
+            createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
+            try {
+                mucAsSeenByOwner.grantMembership(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' member status in room '" + mucAddress + "'.");
+            }
+
+            mucAsSeenByMember.join(nicknameMember);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (joined as '" + nicknameMember + "', a member, not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (joined as '" + nicknameMember + "', a member, not a room owner) tried to destroy room '" + mucAddress);
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request cannot be issued by a non-owner (but an outcast).
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testAuthorizationOutcast() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-outcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            try {
+                mucAsSeenByOwner.banUser(conTwo.getUser().asBareJid(), "Make outcast for integration testing.");
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to make '" + conTwo.getUser().asBareJid() + "' outcast in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (an outcast, not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (an outcast, not a room owner) tried to destroy room '" + mucAddress);
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request cannot be issued by a non-owner (but a non-affiliated participant).
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testAuthorizationParticipant() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-participant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -418,13 +552,50 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
 
             // Verify result.
             final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
-                "Expected an error to be returned when '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
-            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', not a room owner) tried to destroy room '" + mucAddress);
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', an unaffiliated participant, not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', an unaffiliated participant, not a room owner) tried to destroy room '" + mucAddress);
         } finally {
             // Tear down test fixture.
             try {
                 if (mucAsSeenByOwner.isJoined()) {
-                    tryDestroy(mucAsSeenByOwner);
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request cannot be issued by a non-owner (but an entity not in the room).
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testAuthorizationNonParticipant() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-nonparticipant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (not joined in the room, not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (not joined in the room, not a room owner) tried to destroy room '" + mucAddress);
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
                 }
             } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
                 // Room was likely already destroyed.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -60,7 +60,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testDestroyPersistentRoom() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-persistent");
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-prst");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -1,0 +1,435 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.ResultSyncPoint;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.Destroy;
+import org.jivesoftware.smackx.muc.packet.MUCOwner;
+import org.jivesoftware.smackx.xdata.form.FillableForm;
+import org.jivesoftware.smackx.xdata.form.Form;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.9 Owner Use Cases: Destroying a Room" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#destroyroom">XEP-0045 Section 10.9</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerDestroyRoomIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that a room that is persistent can be destroyed.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "A room owner MUST be able to destroy a room, especially if the room is persistent.")
+    public void testDestroyPersistentRoom() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-persistent");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // TODO find a way to configure the room as persistent upon creation, not immediately after it was created.
+            final Form configForm = mucAsSeenByOwner.getConfigurationForm();
+            if (configForm.hasField("muc#roomconfig_persistentroom") && !configForm.readBoolean("muc#roomconfig_persistentroom")) {
+                final FillableForm answerForm = configForm.getFillableForm();
+                answerForm.setAnswer("muc#roomconfig_persistentroom", true);
+                try {
+                    mucAsSeenByOwner.sendConfigurationForm(answerForm);
+                } catch (XMPPException.XMPPErrorException e) {
+                    throw new TestNotPossibleException("Service does not allow room to be configured as a persistent room.");
+                }
+            }
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy the persistent room '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room that is temporary can be destroyed.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "A room owner MUST be able to destroy a room")
+    public void testDestroyTemporaryRoom() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-temporary");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // TODO find a way to configure the room as temporary upon creation, not immediately after it was created.
+            final Form configForm = mucAsSeenByOwner.getConfigurationForm();
+            if (configForm.hasField("muc#roomconfig_persistentroom") && configForm.readBoolean("muc#roomconfig_persistentroom")) {
+                final FillableForm answerForm = configForm.getFillableForm();
+                answerForm.setAnswer("muc#roomconfig_persistentroom", false);
+                try {
+                    mucAsSeenByOwner.sendConfigurationForm(answerForm);
+                } catch (XMPPException.XMPPErrorException e) {
+                    throw new TestNotPossibleException("Service does not allow room to be configured as a temporary room.");
+                }
+            }
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy the temporary room '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request can contain an alternate venue.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute.")
+    public void testAlternateVenue() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenue");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(JidCreate.entityBareFrom("alternate@muc.example.org"), null));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy room '" + mucAddress + "' while providing an alternative venue (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+// TODO enable this once SMACK-950 gets fixed.
+//    /**
+//     * Verifies that a room destruction request can contain an alternate venue and alternate venue password.
+//     */
+//    @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The address of the alternate venue MAY be provided as the value of the <destroy/> element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a <password/> child element of the <destroy/> element.")
+//    public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenuepassword");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        try {
+//            createMuc(mucAsSeenByOwner, nicknameOwner);
+//
+//            // Execute system under test.
+//            final MUCOwner request = new MUCOwner();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.setDestroy(new Destroy(JidCreate.entityBareFrom("alternate@muc.example.org"), "secret", null));
+//            try {
+//                conOne.sendIqRequestAndWaitForResponse(request);
+//
+//                // Verify result.
+//            } catch (XMPPException.XMPPErrorException e) {
+//                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy room '" + mucAddress + "' while providing an alternative venue and password (but the server returned an error).", e);
+//            }
+//        } finally {
+//            // Tear down test fixture.
+//            try {
+//                if (mucAsSeenByOwner.isJoined()) {
+//                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+//                }
+//            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+//                // Room was likely already destroyed.
+//            }
+//        }
+//    }
+
+    /**
+     * Verifies that a room destruction request can contain a reason.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. [...] The reason for the room destruction MAY be provided as the XML character data of a <reason/> child element of the <destroy/> element.")
+    public void testReason() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, "Room destroyed as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to destroy room '" + mucAddress + "' while providing reason for the destruction (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request causes all occupants to be removed.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room.")
+    public void testPresence() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presence");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final SimpleResultSyncPoint ownerSeesDestroy = new SimpleResultSyncPoint();
+        final SimpleResultSyncPoint participantSeesDestroy = new SimpleResultSyncPoint();
+        final UserStatusListener ownerListener = new UserStatusListener() {
+            @Override
+            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+                ownerSeesDestroy.signal();
+            }
+        };
+        final UserStatusListener participantListener = new UserStatusListener() {
+            @Override
+            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+                participantSeesDestroy.signal();
+            }
+        };
+        mucAsSeenByOwner.addUserStatusListener(ownerListener);
+        mucAsSeenByParticipant.addUserStatusListener(participantListener);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertResult(ownerSeesDestroy, "Expected owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
+            assertResult(participantSeesDestroy, "Expected participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
+        } finally {
+            // Tear down test fixture.
+            mucAsSeenByOwner.removeUserStatusListener(ownerListener);
+            mucAsSeenByParticipant.removeUserStatusListener(participantListener);
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request causes all occupants to be removed, receiving a notification that contains
+     * all optional data.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.")
+    public void testPresenceOptional() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presenceext");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        final EntityBareJid alternateVenue = JidCreate.entityBareFrom("alternate@muc.example.org");
+        final String password = "secret"; // TODO use this after SMACK-950 gets resolved.
+        final String reason = "Destroying room as part of an integration test";
+
+        final ResultSyncPoint<Destroy, Exception> ownerSeesDestroy = new ResultSyncPoint<>();
+        final ResultSyncPoint<Destroy, Exception> participantSeesDestroy = new ResultSyncPoint<>();
+        final UserStatusListener ownerListener = new UserStatusListener() {
+            @Override
+            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+                ownerSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), reason));
+            }
+        };
+        final UserStatusListener participantListener = new UserStatusListener() {
+            @Override
+            public void roomDestroyed(MultiUserChat alternateMUC, String reason) {
+                participantSeesDestroy.signal(new Destroy(alternateMUC == null ? null : alternateMUC.getRoom(), reason));
+            }
+        };
+        mucAsSeenByOwner.addUserStatusListener(ownerListener);
+        mucAsSeenByParticipant.addUserStatusListener(participantListener);
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(alternateVenue, reason));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            final Destroy ownerDestroy = assertResult(ownerSeesDestroy, "Expected owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
+            assertEquals(alternateVenue, ownerDestroy.getJid(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the alternate venue address that was provided in the destruction request (but that was found in the received presence).");
+            // TODO enable this after SMACK-950 gets resolved // assertEquals(password, ownerDestroy.getPassword(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
+            assertEquals(reason, ownerDestroy.getReason(), "Expected the presence received by owner '" + conOne.getUser() + "' (joined as '" + nicknameOwner + "') after room '" + mucAddress + "' got destroyed to include the reason that was provided in the destruction request (but that was found in the received presence).");
+            final Destroy participantDestroy = assertResult(participantSeesDestroy, "Expected participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') to be notified of destruction of room '" + mucAddress + "' (but no such notification was received).");
+            assertEquals(alternateVenue, participantDestroy.getJid(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the alternate venue address that was provided in the destruction request (but that was found in the received presence).");
+            // TODO enable this after SMACK-950 gets resolved // assertEquals(password, participantDestroy.getPassword(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the alternate venue password that was provided in the destruction request (but that was found in the received presence).");
+            assertEquals(reason, participantDestroy.getReason(), "Expected the presence received by participant '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after room '" + mucAddress + "' got destroyed to include the reason that was provided in the destruction request (but that was found in the received presence).");
+        } finally {
+            // Tear down test fixture.
+            mucAsSeenByOwner.removeUserStatusListener(ownerListener);
+            mucAsSeenByParticipant.removeUserStatusListener(participantListener);
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner); // If the test fails, then this is also likely to fail.
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+
+    /**
+     * Verifies that a room destruction request cannot be issued by a non-owner.
+     */
+    @SmackIntegrationTest(section = "10.9", quote = "If the <user@host> of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender")
+    public void testAuthorization() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, TimeoutException
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        try {
+            createMuc(mucAsSeenByOwner, nicknameOwner);
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCOwner request = new MUCOwner();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.setDestroy(new Destroy(null, null));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException xmppErrorException = assertThrows(XMPPException.XMPPErrorException.class, () -> { conTwo.sendIqRequestAndWaitForResponse(request); },
+                "Expected an error to be returned when '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', not a room owner) tried to destroy room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.forbidden, xmppErrorException.getStanzaError().getCondition(), "Unexpected condition in the (expected) error after '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "', not a room owner) tried to destroy room '" + mucAddress);
+        } finally {
+            // Tear down test fixture.
+            try {
+                if (mucAsSeenByOwner.isJoined()) {
+                    tryDestroy(mucAsSeenByOwner);
+                }
+            } catch (XMPPException.XMPPErrorException e) { // TODO remove this catch after SMACK-949 gets fixed.
+                // Room was likely already destroyed.
+            }
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
@@ -1,0 +1,495 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for section "10.6 Owner Use Cases: Granting Admin Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantadmin">XEP-0045 Section 10.6</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerGrantAdminIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads (in section 5.2) "Support for the admin [...] is RECOMMENDED."
+        // which suggests that this is optional functionality. The specification does not explicitly say how to test for
+        // support. This implementation will use any XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.grantAdmin(conTwo.getUser().asBareJid());
+        } catch (XMPPException.XMPPErrorException e) {
+            throw new TestNotPossibleException("Service does not support granting of admin status functionality.");
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant admin status to a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "An owner can grant admin status to a member or an unaffiliated user; this is done by changing the user's affiliation to \"admin\"")
+    public void testGrantAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant admin status to '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+    
+    /**
+     * Verifies that an owner can grant admin status to a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "An owner can grant admin status to a member or an unaffiliated user; this is done by changing the user's affiliation to \"admin\"")
+    public void testGrantAdminWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant admin status to '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant admin status to a user that is currently not in the room, while providing a 'reason'.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "An owner can grant admin status to a member or an unaffiliated user; this is done by changing the user's affiliation to \"admin\" [...] The <reason/> element is OPTIONAL.")
+    public void testGrantAdminOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant admin status to '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant admin status to a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "An owner can grant admin status to a member or an unaffiliated user; this is done by changing the user's affiliation to \"admin\" [...] The <reason/> element is OPTIONAL.")
+    public void testGrantAdminOptionalReasonWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-reason-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant admin status to '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict granting of admin status to owners.
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToGrantAdminStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToGrantAdminStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToGrantAdminStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToGrantAdminStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that a (bare) JID that is granted admin status by an owner appears on the Admin List.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "An owner can grant admin status to a member or an unaffiliated user [...] The service MUST add the user to the admin list  [...]")
+    public void testAdminOnAdminList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-on-adminlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertTrue(mucAsSeenByOwner.getAdmins().stream().anyMatch(owner -> owner.getJid().equals(conTwo.getUser().asBareJid())), "Expected '" + conTwo.getUser().asBareJid() + "' to be on the Admin List after they were granted admin status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but the JID does not appear on the Admin List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant is granted admin status.
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of admin status by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"admin\" [...]")
+    public void testOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeeSGrant = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminGranted() {
+                    targetSeesGrant.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        participantSeeSGrant.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertResult(targetSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status, after they are granted admin status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status, after '" + targetMucAddress + "' is granted admin status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(participantSeeSGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of admin status, after '" + targetMucAddress + "' is granted admin status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
@@ -1,0 +1,495 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for section "10.3 Owner Use Cases: Granting Owner Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantowner">XEP-0045 Section 10.3</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerGrantOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads "If allowed by an implementation, an owner MAY grant owner status to another user"
+        // which suggests that this is optional functionality. The specification does not explicitly say how to test for
+        // support. This implementation will use any XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.grantOwnership(conTwo.getUser().asBareJid());
+        } catch (XMPPException.XMPPErrorException e) {
+            throw new TestNotPossibleException("Service does not support granting of owner status functionality.");
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant owner status to a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "an owner MAY grant owner status to another user; this is done by changing the user's affiliation to \"owner\"")
+    public void testGrantOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant owner status to '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+    
+    /**
+     * Verifies that an owner can grant owner status to a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "an owner MAY grant owner status to another user; this is done by changing the user's affiliation to \"owner\"")
+    public void testGrantOwnerWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant owner status to '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant owner status to a user that is currently not in the room, while providing a 'reason'.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "an owner MAY grant owner status to another user; this is done by changing the user's affiliation to \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testGrantOwnerOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant owner status to '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can grant owner status to a user that is currently a participant in the room, while providing a 'reason'.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "an owner MAY grant owner status to another user; this is done by changing the user's affiliation to \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testGrantOwnerOptionalReasonWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-reason-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(request);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to grant owner status to '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict granting of owner status to owners.
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToGrantOwnerStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToGrantOwnerStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToGrantOwnerStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToGrantOwnerStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            // Execute system under test.
+//            final MUCAdmin request = new MUCAdmin();
+//            request.setTo(mucAddress);
+//            request.setType(IQ.Type.set);
+//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(request);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that a (bare) JID that is granted owner status by an owner appears on the Owner List.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "an owner MAY grant owner status to another user [...] The service MUST add the user to the owner list [...]")
+    public void testOwnerOnOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-on-ownerlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertTrue(mucAsSeenByOwner.getOwners().stream().anyMatch(owner -> owner.getJid().equals(conTwo.getUser().asBareJid())), "Expected '" + conTwo.getUser().asBareJid() + "' to be on the Owner List after they were granted owner status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but the JID does not appear on the Owner List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant is granted owner status.
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of owner status by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"owner\" [...]")
+    public void testOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrant = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeeSGrant = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipGranted() {
+                    targetSeesGrant.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesGrant.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        participantSeeSGrant.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(request);
+
+            // Verify result.
+            assertResult(targetSeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of owner status, after they are granted owner status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of owner status, after '" + targetMucAddress + "' is granted owner status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(participantSeeSGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of owner status, after '" + targetMucAddress + "' is granted owner status by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for section "10 Owner Use Cases" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#owner">XEP-0045 Section 10</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException,
+        InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
+    {
+        super(environment);
+    }
+
+    /**
+     * Verifies that a room has an owner, even after the original owner leaves the room.
+     */
+    @SmackIntegrationTest(section = "10", quote = "Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room).")
+    public void testRoomHasOwnerAfterOriginalOwnerLeaves() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-after-leave");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("participant-" + randomString);
+
+        final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameAdmin);
+
+            final SimpleResultSyncPoint participantSeesOwnerLeave = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void left(EntityFullJid participant) {
+                    if (participant.equals(ownerMucAddress)) {
+                        participantSeesOwnerLeave.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            mucAsSeenByOwner.leave();
+            final List<Affiliate> owners = mucAsSeenByParticipant.getOwners();
+
+            // Verify result.
+            assertFalse(owners.isEmpty(), "Room '" + mucAddress + "' unexpectedly has no owners, after the user that created the room ('" + conOne.getUser() + "') left.");
+        } finally {
+            // Tear down test fixture.
+            mucAsSeenByOwner.join(nicknameOwner);
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
@@ -1,0 +1,617 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.5 Owner Use Cases: Modifying the Owner List" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyowner">XEP-0045 Section 10.5</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerOwnerListIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads "If allowed by an implementation, a room owner might want to modify the owner list"
+        // which suggests that this is optional functionality. The specification does not explicitly say how to test for
+        // support. This implementation will use any XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-list-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.getOwners();
+            muc.grantOwnership(Set.of(conOne.getUser().asBareJid(), conTwo.getUser().asBareJid()));
+        } catch (XMPPException.XMPPErrorException e) {
+            throw new TestNotPossibleException("Service does not support modification of the owner list.");
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Asserts that an owner list can be obtained.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "the owner [...] requests the owner list by querying the room for all users with an affiliation of 'owner'")
+    public void testOwnerRequestsOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-requests-ownerlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.owner));
+            conOne.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+        } catch (XMPPException.XMPPErrorException e) {
+            fail("Expected owner '" + conOne.getUser() + "' to be able to receive the owner list from '" + mucAddress + "' (but the server returned an error).", e);
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a user (not in the room, that is semi-anonymous) cannot request the owner list.
+     *
+     * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserRequestsOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-ownerlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createSemiAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.owner));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not in the room) to receive an error when requesting the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not in the room) after it requested the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a participant (that is in a semi-anonymous room) cannot request the owner list.
+     *
+     * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantRequestsOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-ownerlist");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createSemiAnonymousMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.owner));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected participant '" + conTwo.getUser() + "' to receive an error when requesting the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is a participant in the room) after it requested the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an owner list item has 'affiliation' and 'jid' attributes.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    public void testOwnerListItemCheck() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-list-itemcheck");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByOwner.grantOwnership(conTwo.getUser().asBareJid());
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.get);
+            iq.addItem(new MUCItem(MUCAffiliation.owner));
+            final MUCAdmin response = conOne.sendIqRequestAndWaitForResponse(iq);
+
+            // Verify result.
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The owner list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The owner list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the owner list requested by '" + conOne.getUser() + "' from '" + mucAddress + "' to include '" + conTwo.getUser().asBareJid() + "' (but it did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an owner list modification can contain more than one item.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items [...] back to the service [...] the service MUST modify owner list and then inform the owner of success")
+    public void testOwnerListMultipleItems() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-multiple");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the owner list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getOwners().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to contain '" + conTwo.getUser().asBareJid() + "' that was just added to the owner list by '" + conOne.getUser() + "' (but does not appear on the owner list).");
+            assertTrue(mucAsSeenByOwner.getOwners().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to contain '" + conThree.getUser().asBareJid() + "' that was just added to the owner list by '" + conOne.getUser() + "' (but does not appear on the owner list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an owner list modification can be used to remove people from the owner list.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items [...] back to the service [...] the service MUST modify owner list and then inform the owner of success")
+    public void testAdminOwnerListMultipleItemsRevoke() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantOwnership(List.of(conTwo.getUser().asBareJid(), conThree.getUser().asBareJid()));
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' and/or '" + conThree.getUser().asBareJid() + "' owner status in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the owner list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getOwners().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to not contain '" + conTwo.getUser().asBareJid() + "' that was just removed from the owner list by '" + conOne.getUser() + "' (but does appear on the owner list).");
+            assertTrue(mucAsSeenByOwner.getOwners().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to not contain '" + conThree.getUser().asBareJid() + "' that was just removed from the owner list by '" + conOne.getUser() + "' (but does appear on the owner list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an owner list modification is a delta: it shouldn't affect entries already on the owner list
+     * that are not included in the delta.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "The owner can then modify the owner list if desired. In order to do so, the owner MUST send the changed items (i.e., only the \"delta\")")
+    public void testOwnerOwnerListIsDelta() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-delta");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantOwnership(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' owner status in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the owner list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+            assertTrue(mucAsSeenByOwner.getOwners().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conOne.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to contain '" + conOne.getUser().asBareJid() + "' after the owner list that previously contained them got updated with different items (which should have been applied as a delta).");
+            assertTrue(mucAsSeenByOwner.getOwners().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conTwo.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to no longer contain '" + conTwo.getUser().asBareJid() + "' that was just removed from the owner list by '" + conOne.getUser() + "' (but does still appear on the owner list).");
+            assertTrue(mucAsSeenByOwner.getOwners().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.owner && i.getJid().equals(conThree.getUser().asBareJid())), "Expected the owner list for '" + mucAddress + "' to contain '" + conThree.getUser().asBareJid() + "' that was just added to the owner list by '" + conOne.getUser() + "' (but does not appear on the owner list).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an admin (non-owner) cannot make an owner list modification.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    public void testOwnerListRejectAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-admin");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' admin status in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByAdmin.join(nicknameAdmin); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but an admin) to receive an error when they attempted to modify the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but an admin) after it attempted to modify the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a member (non-owner) cannot make an owner list modification.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    public void testOwnerListRejectMember() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-member");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameMember = Resourcepart.from("member-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantMembership(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' membership in room '" + mucAddress + "'.");
+            }
+            mucAsSeenByMember.join(nicknameMember); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but a member) to receive an error when they attempt to modify the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but a member) after it attempted to modify the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that an outcast (non-owner) cannot make an owner list modification.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    public void testOwnerListRejectOutcast() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-member");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.banUser(conTwo.getUser().asBareJid(), "Made outcast as part of an integration test.");
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to make '" + conTwo.getUser().asBareJid() + "' an outcast in room '" + mucAddress + "'.");
+            }
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but an outcast) to receive an error when they attempt to modify the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but an outcast) after it attempted to modify the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that a user without an affiliation (non-owner) cannot make an owner list modification.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    public void testOwnerListRejectNoneAffiliation() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-nonaff");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant); // Not strictly needed.
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conTwo.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conTwo.getUser() + "' (that is not an owner but a user without an affiliation) to receive an error when they attempt to modify the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an owner but a user without an affiliation) after it attempted to modify the owner list of room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Asserts that the last owner cannot remove itself as an owner through a owner list modification.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a <conflict/> error to the owner.")
+    public void testOwnerListRejectRemovalLastOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-remove-last");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conOne.getUser().asBareJid()));
+
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conOne.sendIqRequestAndWaitForResponse(iq),
+                "Expected user '" + conOne.getUser() + "' (that is the only owner of the room) to receive an error when they attempt to revoke their own owner status through modification of the owner list from '" + mucAddress + "' (but the server did not return an error).");
+            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' (that is the only owner of the room) after it attempted to revoke their own owner status through modification of the owner list room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when owner list changes are made.
+     */
+    @SmackIntegrationTest(section = "10.5", quote = "The service MUST also send presence notifications related to any affiliation changes that result from modifying the owner list [...]")
+    public void testAdminOwnerListBroadcast() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
+        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+
+        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
+        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            try {
+                mucAsSeenByOwner.grantOwnership(conTwo.getUser().asBareJid());
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser().asBareJid() + "' owner status in room '" + mucAddress + "'.");
+            }
+
+            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesTarget1.signal();
+                    }
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesTarget2.signal();
+                    }
+                }
+            });
+
+            mucAsSeenByTarget1.join(nicknameTarget1);
+            mucAsSeenByTarget2.join(nicknameTarget2);
+
+            ownerSeesTarget1.waitForResult(timeout);
+            ownerSeesTarget2.waitForResult(timeout);
+
+            final SimpleResultSyncPoint ownerSeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target1SeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesRevokeTarget1 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint target2SeesGrantTarget2 = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        ownerSeesGrantTarget2.signal();
+                    }
+                }
+
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        ownerSeesRevokeTarget1.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget1.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipRevoked() {
+                    target1SeesRevokeTarget1.signal();
+                }
+            });
+            mucAsSeenByTarget1.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipGranted(EntityFullJid participant) {
+                    if (participant.equals(target2MucAddress)) {
+                        target1SeesGrantTarget2.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget2.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipGranted() {
+                    target2SeesGrantTarget2.signal();
+                }
+            });
+            mucAsSeenByTarget2.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (participant.equals(target1MucAddress)) {
+                        target2SeesRevokeTarget1.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin iq = new MUCAdmin();
+            iq.setTo(mucAddress);
+            iq.setType(IQ.Type.set);
+            iq.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            iq.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(iq);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the owner list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+            }
+
+            assertResult(ownerSeesRevokeTarget1, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status of '" + conTwo.getUser().asBareJid() + "' (but did not).");
+            assertResult(ownerSeesGrantTarget2, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status of '" + conThree.getUser().asBareJid() + "' (but did not).");
+            assertResult(target1SeesRevokeTarget1, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status for themself (but did not).");
+            assertResult(target1SeesGrantTarget2, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status of '" + conThree.getUser().asBareJid() + "' (but did not).");
+            assertResult(target2SeesRevokeTarget1, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status of '" + conTwo.getUser().asBareJid() + "' (but did not).");
+            assertResult(target2SeesGrantTarget2, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in owner status for themself' (but did not).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
@@ -165,7 +165,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     }
 
     /**
-     * Verifies that an owner can revoke admin status from a user that is currently not in the room.
+     * Verifies that an owner can revoke admin status from a user that is currently not in the room, and give a reason.
      */
     @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\" [...] The <reason/> element is OPTIONAL.")
     public void testRevokeAdminOptionalReason() throws Exception
@@ -203,7 +203,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     }
 
     /**
-     * Verifies that an owner can revoke admin status from a user that is currently a participant in the room.
+     * Verifies that an owner can revoke admin status from a user that is currently a participant in the room, and provide a reason.
      */
     @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\" [...] The <reason/> element is OPTIONAL.")
     public void testRevokeAdminOptionalReasonWhileInRoom() throws Exception

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
@@ -1,0 +1,577 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Tests for section "10.7 Owner Use Cases: Revoking Admin Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeadmin">XEP-0045 Section 10.7</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerRevokeAdminIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads (in section 5.2) "Support for the admin [...] is RECOMMENDED."
+        // which suggests that this is optional functionality. The specification does not explicitly say how to test for
+        // support. This implementation will use any XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.grantAdmin(conTwo.getUser().asBareJid());
+            muc.revokeAdmin(conTwo.getUser().asEntityBareJid());
+        } catch (XMPPException.XMPPErrorException e) {
+            if (StanzaError.Condition.not_authorized.equals(e.getStanzaError().getCondition())) {
+                throw new TestNotPossibleException("Service does not support granting and/or revokation of admin status functionality.");
+            } else {
+                throw e;
+            }
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke admin status from a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\"")
+    public void testRevokeAdmin() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke admin status from '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke admin status from a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\"")
+    public void testRevokeAdminWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke admin status from '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke admin status from a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeAdminOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid(), "Revoking Admin Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke admin status from '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke admin status from a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status; this is done by changing the user's affiliation to something other than \"admin\" or \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeAdminOptionalReasonWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-reason-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid(), "Revoking Admin Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke admin status from '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict revokation of admin status to owners.
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToRevokeAdminStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToRevokeAdminStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToRevokeAdminStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToRevokeAdminStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that an admin that got its admin status removed no longer exists on the admin list.
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "An owner might want to revoke a user's admin status [...] The service MUST remove the user from the admin list [...] ")
+    public void testOwnerNotOnOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-not-on-admin-list");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected owner '" + conOne.getUser() + "' to be able to revoke admin status from '" + conTwo.getUser() + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(mucAsSeenByOwner.getAdmins().stream().anyMatch(owner -> owner.getJid().equals(conTwo.getUser().asBareJid())), "Expected '" + conTwo.getUser().asBareJid() + "' to no longer be on the Admin List after their admin status was removed '" + conOne.getUser() + "' in '" + mucAddress + "' (but the JID does still appear on the Admin List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant gets its admin status revoked
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of admin status by sending a presence element that contains an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value other than \"admin\" or \"owner\" [...]")
+    public void testOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin requestGrant = new MUCAdmin();
+            requestGrant.setTo(mucAddress);
+            requestGrant.setType(IQ.Type.set);
+            requestGrant.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(requestGrant);
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void adminRevoked() {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void adminRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        participantSeesRevoke.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin requestRevoke = new MUCAdmin();
+            requestRevoke.setTo(mucAddress);
+            requestRevoke.setType(IQ.Type.set);
+            requestRevoke.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(requestRevoke);
+
+            // Verify result.
+            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status, after their admin status is revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status, after '" + targetMucAddress + "' has their admin status revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(participantSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of admin status, after '" + targetMucAddress + "' has their admin status revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
@@ -1,0 +1,607 @@
+/**
+ * Copyright 2024 Guus der Kinderen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jivesoftware.smackx.muc;
+
+import org.igniterealtime.smack.inttest.SmackIntegrationTestEnvironment;
+import org.igniterealtime.smack.inttest.TestNotPossibleException;
+import org.igniterealtime.smack.inttest.annotations.SmackIntegrationTest;
+import org.igniterealtime.smack.inttest.annotations.SpecificationReference;
+import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
+import org.jivesoftware.smack.SmackException;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
+import org.jivesoftware.smackx.muc.packet.MUCAdmin;
+import org.jivesoftware.smackx.muc.packet.MUCItem;
+import org.jxmpp.jid.EntityBareJid;
+import org.jxmpp.jid.EntityFullJid;
+import org.jxmpp.jid.impl.JidCreate;
+import org.jxmpp.jid.parts.Resourcepart;
+import org.jxmpp.stringprep.XmppStringprepException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for section "10.4 Owner Use Cases: Revoking Owner Status" of XEP-0045: "Multi-User Chat"
+ *
+ * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeowner">XEP-0045 Section 10.4</a>
+ */
+@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
+{
+    public MultiUserChatOwnerRevokeOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)
+        throws SmackException.NoResponseException, XMPPException.XMPPErrorException,
+        SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException
+    {
+        super(environment);
+
+        // The specification reads "An implementation MAY allow an owner to revoke another user's owner status;" and
+        // "If an implementation does not allow one owner to revoke another user's owner status, the implementation MUST
+        // return a <not-authorized/> error to the owner who made the request."
+        // This implementation will use that XMPP error in response to a change request as an indication that
+        // the feature is not supported by the server under test.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-support");
+        final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
+        createMuc(muc, Resourcepart.from("owner-" + randomString));
+        try {
+            muc.grantOwnership(conTwo.getUser().asBareJid());
+            muc.revokeOwnership(conTwo.getUser().asBareJid());
+        } catch (XMPPException.XMPPErrorException e) {
+            if (StanzaError.Condition.not_authorized.equals(e.getStanzaError().getCondition())) {
+                throw new TestNotPossibleException("Service does not support granting and/or revokation of owner status functionality.");
+            } else {
+                throw e;
+            }
+        } finally {
+            tryDestroy(muc);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke owner status from a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "An implementation MAY allow an owner to revoke another user's owner status; this is done by changing the user's affiliation to something other than \"owner\"")
+    public void testRevokeOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke owner status from '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke owner status from a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "An implementation MAY allow an owner to revoke another user's owner status; this is done by changing the user's affiliation to something other than \"owner\"")
+    public void testRevokeOwnerWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke owner status from '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke owner status from a user that is currently not in the room.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "An implementation MAY allow an owner to revoke another user's owner status; this is done by changing the user's affiliation to something other than \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeOwnerOptionalReason() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-reason");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid(), "Revoking Owner Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke owner status from '" + conTwo.getUser().asBareJid() + "' in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner can revoke owner status from a user that is currently a participant in the room.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "An implementation MAY allow an owner to revoke another user's owner status; this is done by changing the user's affiliation to something other than \"owner\" [...] The <reason/> element is OPTIONAL.")
+    public void testRevokeOwnerOptionalReasonWhileInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-reason-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid(), "Revoking Owner Status as part of an integration test."));
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+
+                // Verify result.
+            } catch (XMPPException.XMPPErrorException e) {
+                fail("Expected owner '" + conOne.getUser() + "' to be able to revoke owner status from '" + conTwo.getUser().asBareJid() + "' (that is currently joined as '" + nicknameTarget+ "') in '" + mucAddress + "' (but the server returned an error).", e);
+            }
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict revokation of owner status to owners.
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToRevokeOwnerStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testUserNotAllowedToRevokeOwnerStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByTarget.join(nicknameTarget);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is not in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToRevokeOwnerStatus() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+//
+//    /**
+//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is in the room).
+//     */
+//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+//    public void testParticipantNotAllowedToRevokeOwnerStatusInRoom() throws Exception
+//    {
+//        // Setup test fixture.
+//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed-inroom");
+//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+//
+//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+//
+//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+//
+//        createMuc(mucAsSeenByOwner, nicknameOwner);
+//        try {
+//            mucAsSeenByParticipant.join(nicknameParticipant);
+//
+//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+//                @Override
+//                public void joined(EntityFullJid participant) {
+//                    if (participant.equals(targetMucAddress)) {
+//                        participantSeesTarget.signal();
+//                    }
+//                }
+//            });
+//            mucAsSeenByTarget.join(nicknameTarget);
+//            participantSeesTarget.waitForResult(timeout);
+//
+//            final MUCAdmin grantRequest = new MUCAdmin();
+//            grantRequest.setTo(mucAddress);
+//            grantRequest.setType(IQ.Type.set);
+//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+//
+//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+//
+//            // Execute system under test.
+//            final MUCAdmin revokeRequest = new MUCAdmin();
+//            revokeRequest.setTo(mucAddress);
+//            revokeRequest.setType(IQ.Type.set);
+//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+//
+//            // Verify result.
+//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+//        } finally {
+//            // Tear down test fixture.
+//            tryDestroy(mucAsSeenByOwner);
+//        }
+//    }
+
+    /**
+     * Verifies that an owner cannot revoke its own owner status when they're the last owner of the room.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "A service MUST NOT allow an owner to revoke his or her own owner status if there are no other owners; if an owner attempts to do this, the service MUST return a <conflict/> error to the owner.")
+    public void testOwnerRemoveLastOwner() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-last");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conOne.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conOne.getUser() + "' (that is the only owner) tried to revoke owner status from itself in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.conflict, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' (that is the only owner) after it tried to revoke owner status from itself in for room '" + mucAddress + "'.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that an owner that got its owner status removed no longer exists on the owner list.
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "An implementation MAY allow an owner to revoke another user's owner status; [...] the service MUST remove the user from the owner list [...] ")
+    public void testOwnerNotOnOwnerList() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-not-on-owner-list");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conTwo.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conTwo.getUser().asBareJid()));
+
+            try {
+                conOne.sendIqRequestAndWaitForResponse(revokeRequest);
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Expected owner '" + conOne.getUser() + "' to be able to revoke owner status from '" + conTwo.getUser() + "' in '" + mucAddress + "' (but the server returned an error).");
+            }
+
+            // Verify result.
+            assertFalse(mucAsSeenByOwner.getOwners().stream().anyMatch(owner -> owner.getJid().equals(conTwo.getUser().asBareJid())), "Expected '" + conTwo.getUser().asBareJid() + "' to no longer be on the Owner List after their owner status was removed '" + conOne.getUser() + "' in '" + mucAddress + "' (but the JID does still appear on the Owner List).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that occupants are notified when an existing occupant gets its owner status revoked
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of owner status by sending a presence element that contains an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value other than \"owner\" [...]")
+    public void testOccupantsInformed() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-broadcast");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin requestGrant = new MUCAdmin();
+            requestGrant.setTo(mucAddress);
+            requestGrant.setType(IQ.Type.set);
+            requestGrant.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(requestGrant);
+
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
+            participantSeesTarget.waitForResult(timeout);
+
+            final SimpleResultSyncPoint targetSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesRevoke = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint participantSeesRevoke = new SimpleResultSyncPoint();
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
+                @Override
+                public void ownershipRevoked() {
+                    targetSeesRevoke.signal();
+                }
+            });
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        ownerSeesRevoke.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void ownershipRevoked(EntityFullJid participant) {
+                    if (targetMucAddress.equals(participant)) {
+                        participantSeesRevoke.signal();
+                    }
+                }
+            });
+
+            // Execute system under test.
+            final MUCAdmin requestRevoke = new MUCAdmin();
+            requestRevoke.setTo(mucAddress);
+            requestRevoke.setType(IQ.Type.set);
+            requestRevoke.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(requestRevoke);
+
+            // Verify result.
+            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of owner status, after their owner status is revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of owner status, after '" + targetMucAddress + "' has their owner status revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(participantSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of owner status, after '" + targetMucAddress + "' has their owner status revoked by '" + conOne.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+}


### PR DESCRIPTION
This contains all tests for section 10 "Owner Use Cases" of XEP-0045.

Some of the tests included here are completely or partially commented out, as they depend on fixes in the underlying library, Smack, such as:
- [SMACK-947](https://igniterealtime.atlassian.net/browse/SMACK-947) / https://github.com/igniterealtime/Smack/pull/614
- [SMACK-949](https://igniterealtime.atlassian.net/browse/SMACK-949)
- [SMACK-950](https://igniterealtime.atlassian.net/browse/SMACK-950) / https://github.com/igniterealtime/Smack/pull/616