### PR TITLE
Improve tests for XEP-0045 Multi-User Chat (section 9)

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -80,7 +80,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (that was not an occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to ban '" + targetAddress + "' (that was not an occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -132,7 +132,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' without providing the optional 'reason' attribute (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -219,7 +219,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' while providing the optional 'reason' attribute (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to ban '" + targetAddress + "' (an existing occupant) from '" + mucAddress + "' while providing the optional 'reason' attribute (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -281,7 +281,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
             mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (that was not an occupant) to be on the Ban List after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (that was not an occupant) to be on the Ban List after the were banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -329,7 +329,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
             mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (an existing occupant) to be on the Ban List after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress +"' (an existing occupant) to be on the Ban List after the were banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but the JID does not appear on the Ban List).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -399,7 +399,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
             mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget + "') of '" + targetAddress + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget + "') of '" + targetAddress + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but the nickname does still appear on the list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -407,7 +407,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     }
 
     /**
-     * Verifies that an occupant that is banned is removed from the room.
+     * Verifies that an occupant that is banned by an admin is removed from the room.
      */
     @SmackIntegrationTest(section = "9.1", quote = "The service MUST also remove any banned users who are in the room by sending a presence stanza of type \"unavailable\" to each banned occupant, including status code 301 in the extended presence information [...]")
     public void testBannedOccupantReceivesRemoval() throws Exception
@@ -455,7 +455,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
             mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
 
             // Verify result.
-            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -463,7 +463,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     }
 
     /**
-     * Verifies that other occupants are notified when an occupant is banned.
+     * Verifies that other occupants are notified when an occupant is banned by an admin.
      */
     @SmackIntegrationTest(section = "9.1", quote = "The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type \"unavailable\" from the banned user to all remaining occupants [...]")
     public void mucTestRemainingOccupantsInformedOfBan() throws Exception
@@ -522,8 +522,8 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
             mucAsSeenByAdmin.banUser(targetAddress, "Banned as part of a test.");
 
             // Verify result.
-            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress + "' is banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -85,7 +85,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
             // Verify result.
         } catch (XMPPException.XMPPErrorException e) {
-            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).", e);
+            fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).", e);
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -94,7 +94,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
 
     /**
-     * Asserts that a ban list is always based on a bare JID.
+     * Asserts that a ban list received by an admin is always based on a bare JID.
      *
      * This test attempts to add a full JID to the ban list (which may/should not be possible, in which case the test
      * stops as 'not possible'), and then retrieves the ban list, asserting that the entry on it either doesn't exist,
@@ -132,11 +132,11 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             try {
                 response = conTwo.sendIqRequestAndWaitForResponse(iq);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid().isEntityFullJid()), "The ban list for '" + mucAddress + "' unexpectedly contained an item with a full JID (where only bare JIDs are allowed).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid().isEntityFullJid()), "The ban list for '" + mucAddress + "' as received by '" + conTwo.getUser() + "' (an admin) unexpectedly contained an item with a full JID (where only bare JIDs are allowed).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -144,9 +144,9 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Asserts that a ban list item has 'affiliation' and 'jid' attributes.
+     * Asserts that a ban list item (as received by admins) has 'affiliation' and 'jid' attributes.
      */
-    @SmackIntegrationTest(section = "9.2", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    @SmackIntegrationTest(section = "9.2", quote = "The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes")
     public void mucTestAdminBanListItemCheck() throws Exception
     {
         // Setup test fixture.
@@ -174,13 +174,13 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             try {
                 response = conTwo.sendIqRequestAndWaitForResponse(iq);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to receive the ban list from '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The ban list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The ban list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
-            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the ban list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include the recently added outcast '" + targetAddress + "' (but it did not).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The ban list for '" + mucAddress + "' as received by '" + conTwo.getUser() + "' (an admin) contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The ban list for '" + mucAddress + "' as received by '" + conTwo.getUser() + "' (an admin) contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the ban list requested by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' to include the recently added outcast '" + targetAddress + "' (but it did not).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -188,7 +188,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Asserts that a ban list modification can contain more than one item.
+     * Asserts that a ban list modification made by an admin can contain more than one item.
      */
     @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items [...] back to the service; After updating the ban list, the service MUST inform the admin of success.")
     public void mucTestAdminBanListMultipleItems() throws Exception
@@ -220,10 +220,10 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the ban list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -262,7 +262,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Asserts that a ban list modification can be used to remove people from the banlist.
+     * Asserts that a ban list modification made by an admin can be used to remove people from the banlist.
      */
     @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. [...] each item MUST include the 'affiliation' attribute (normally set to a value of \"outcast\" to ban or \"none\" to remove ban)")
     public void mucTestAdminBanListMultipleItemsUnban() throws Exception
@@ -296,10 +296,10 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (but does appear on the ban list).");
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (but does appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (an admin) (but does appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the ban list by '" + conTwo.getUser() + "' (an admin) (but does appear on the ban list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -307,7 +307,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Asserts that a ban list modification can contain more than one item, that have optional attributes set.
+     * Asserts that a ban list modification made by an admin can contain more than one item, that have optional attributes set.
      */
     @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items [...] back to the service; After updating the ban list, the service MUST inform the admin of success.")
     public void mucTestAdminBanListMultipleItemsWithOptionalAttributes() throws Exception
@@ -339,10 +339,10 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
-            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress1)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the ban list).");
+            assertTrue(mucAsSeenByAdmin.getOutcasts().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.outcast && i.getJid().equals(targetAddress2)), "Expected the ban list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the ban list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the ban list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -350,8 +350,8 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Asserts that a ban list modification is a delta: it shouldn't affect entries already on the ban list that are
-     * not included in the delta.
+     * Asserts that a ban list modification made by an admin is a delta: it shouldn't affect entries already on the ban
+     * list that are not included in the delta.
      */
     @SmackIntegrationTest(section = "9.2", quote = "The admin can then modify the ban list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\") [...]")
     public void mucTestAdminBanListIsDelta() throws Exception
@@ -385,13 +385,13 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the ban list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
 
             final Set<Jid> outcasts = mucAsSeenByAdmin.getOutcasts().stream().filter(i -> i.getAffiliation().equals(MUCAffiliation.outcast)).map(Affiliate::getJid).collect(Collectors.toSet());
-            assertFalse(outcasts.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the ban list of '" + mucAddress + "', after '" + conTwo.getUser() + "' updated the ban list that previously contained them with their removal (but does still appear on the ban list).");
-            assertTrue(outcasts.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously contained them got updated by '" + conTwo.getUser() + "' with different items (which should have been applied as a delta).");
-            assertTrue(outcasts.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously did not contain them got updated by '" + conTwo.getUser() + "' with items that include them.");
+            assertFalse(outcasts.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the ban list of '" + mucAddress + "', after '" + conTwo.getUser() + "' (an admin) updated the ban list that previously contained them with their removal (but does still appear on the ban list).");
+            assertTrue(outcasts.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously contained them got updated by '" + conTwo.getUser() + "' (an admin) with different items (which should have been applied as a delta).");
+            assertTrue(outcasts.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the ban list of '" + mucAddress + "', after the ban list that previously did not contain them got updated by '" + conTwo.getUser() + "' (an admin) with items that include them.");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -399,7 +399,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Verifies that occupants that are banned by modification of the banlist are removed from the room.
+     * Verifies that occupants that are banned by modification of the banlist by an admin are removed from the room.
      */
     @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST then remove the affected occupants (if they are in the room)")
     public void mucTestBanListOccupantsInformedOfBan() throws Exception
@@ -448,7 +448,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(targetSeesBan, "Expected '" + conThree.getUser() + "' to receive a presence stanza of type \"unavailable\" including status code 301 in the extended presence information after being banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -456,7 +456,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Verifies that other occupants are notified when banlist changes are made.
+     * Verifies that other occupants are notified when banlist changes are made by an admin.
      */
     @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST then remove the affected occupants [...] and send updated presence (including the appropriate status code) from them to all the remaining occupants")
     public void mucTestBanListRemainingOccupantsInformedOfBan() throws Exception
@@ -516,8 +516,8 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesBan, "Expected '" + conOne.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesBan, "Expected '" + conTwo.getUser() + "' to receive a presence stanza of type \"unavailable\" of '" + targetMucAddress + "' including status code 301 in the extended presence information after '" + targetAddress1 + "' is banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -525,8 +525,8 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     }
 
     /**
-     * Verifies that entities banned from a room through ban list modifications get their nickname removed from the list
-     * of registered nicknames.
+     * Verifies that entities banned by an admin from a room through ban list modifications get their nickname removed
+     * from the list of registered nicknames.
      */
     @SmackIntegrationTest(section = "9.2", quote = "After updating the ban list [...] The service MUST also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.")
     public void mucTestBanListRemovesRegisteredNickname() throws Exception
@@ -577,8 +577,8 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             mucAsSeenByAdmin.banUsers(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget1.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget1 + "') of '" + targetAddress1 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget2.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget2 + "') of '" + targetAddress2 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo + "' from '" + mucAddress + "' (but the nickname does still appear on the list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget1.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget1 + "') of '" + targetAddress1 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but the nickname does still appear on the list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(affiliate -> nicknameTarget2.equals(affiliate.getNick())), "Expected the registered nickname ('" + nicknameTarget2 + "') of '" + targetAddress2 + "' to no longer be on the list of registered nicknames after the were banned by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but the nickname does still appear on the list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -80,7 +80,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "'(an admin) to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -120,7 +120,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -159,7 +159,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -232,11 +232,11 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
             try {
                 conTwo.sendIqRequestAndWaitForResponse(request);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin)to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress + "' to be on the Member List after the were granted membership by '" + conTwo + "' to '" + mucAddress + "' (but the JID does not appear on the Member List).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(affiliate -> affiliate.getJid().equals(targetAddress)), "Expected '" + targetAddress + "' to be on the Member List after the were granted membership by '" + conTwo.getUser() + "' (an admin) to '" + mucAddress + "' (but the JID does not appear on the Member List).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -244,7 +244,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     }
 
     /**
-     * Verifies that occupants are notified when an existing occupant is granted membership.
+     * Verifies that occupants are notified when an existing occupant is granted membership by an admin.
      */
     @SmackIntegrationTest(section = "9.3", quote = "If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\".")
     public void mucTestOccupantsInformed() throws Exception
@@ -312,13 +312,13 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
             try {
                 mucAsSeenByAdmin.grantMembership(targetAddress);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant membership to '" + targetAddress + "' in '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertResult(targetSeesMembership, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after they are granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(ownerSeesMembership, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(adminSeesMembership, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(targetSeesMembership, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after they are granted membership by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesMembership, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesMembership, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of membership, after '" + targetAddress + "' is granted membership by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -94,7 +94,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -148,7 +148,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' when providing an optional 'reason' element (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' when providing an optional 'reason' element (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -251,11 +251,11 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
             try {
                 conTwo.sendIqRequestAndWaitForResponse(request);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertTrue(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to be on the Moderator List after the were granted moderator status by '" + conTwo + "' in '" + mucAddress + "' (but the nickname does not appear on the Moderator List).");
+            assertTrue(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to be on the Moderator List after the were granted moderator status by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but the nickname does not appear on the Moderator List).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -263,7 +263,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     }
 
     /**
-     * Verifies that occupants are notified when an existing occupant is granted moderator status.
+     * Verifies that occupants are notified when an existing occupant is granted moderator status by an admin.
      */
     @SmackIntegrationTest(section = "9.6", quote = "The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'role' attribute set to a value of \"moderator\".")
     public void mucTestOccupantsInformed() throws Exception {
@@ -333,13 +333,13 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
             try {
                 conTwo.sendIqRequestAndWaitForResponse(request);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant moderator status to '" + nicknameTarget + "' in '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Verify result.
-            assertResult(targetSeesModerator, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after they are granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(ownerSeesModerator, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(adminSeesModerator, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(targetSeesModerator, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after they are granted moderator status by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesModerator, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesModerator, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the granting of moderator status, after '" + targetMucAddress + "' is granted moderator status by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -58,7 +58,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Asserts that a member list can be obtained.
+     * Asserts that a member list can be obtained by an admin.
      */
     @SmackIntegrationTest(section = "9.5", quote = "The admin [...] requests the member list by querying the room for all users with an affiliation of \"member\"")
     public void mucTestAdminRequestsMemberList() throws Exception
@@ -85,7 +85,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
 
             // Verify result.
         } catch (XMPPException.XMPPErrorException e) {
-            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the member list from '" + mucAddress + "' (but the server returned an error).", e);
+            fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to receive the member list from '" + mucAddress + "' (but the server returned an error).", e);
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -93,9 +93,9 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Asserts that a member list item has 'affiliation' and 'jid' attributes.
+     * Asserts that a member list item received by an admin has 'affiliation' and 'jid' attributes.
      */
-    @SmackIntegrationTest(section = "9.5", quote = "each item MUST include the 'affiliation' and 'jid' attributes")
+    @SmackIntegrationTest(section = "9.5", quote = "The service MUST then return the full member list to the admin [...]; each item MUST include the 'affiliation' and 'jid' attributes")
     public void mucTestAdminMemberListItemCheck() throws Exception
     {
         // Setup test fixture.
@@ -120,9 +120,9 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
             final MUCAdmin response = conTwo.sendIqRequestAndWaitForResponse(iq);
 
             // Verify result.
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The member list for '" + mucAddress + "' contains an item that does not have a 'jid' attribute (but all items must have one).");
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The member list for '" + mucAddress + "' contains an item that does not have an 'affiliation' attribute (but all items must have one).");
-            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the member list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include the recently added member '" + targetAddress + "' (but it did not).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getJid() == null), "The member list for '" + mucAddress + "' as requested by '" + conTwo.getUser() + "' (an admin) contains an item that does not have a 'jid' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getAffiliation() == null), "The member list for '" + mucAddress + "' as requested by '" + conTwo.getUser() + "' (an admin) contains an item that does not have an 'affiliation' attribute (but all items must have one).");
+            assertTrue(response.getItems().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Expected the member list requested by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' to include the recently added member '" + targetAddress + "' (but it did not).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -130,7 +130,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Asserts that a member list modification can contain more than one item.
+     * Asserts that a member list modification made by an admin can contain more than one item.
      */
     @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. In order to do so, the admin MUST send the changed items [...] to the service; [...] The service MUST modify the member list and then inform the moderator of success:")
     public void mucTestAdminMemberListMultipleItems() throws Exception
@@ -162,10 +162,10 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the member list by '" + conTwo.getUser() + "' (but does not appear on the member list).");
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the member list by '" + conTwo.getUser() + "' (but does not appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress1 + "' that was just added to the member list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().anyMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to contain '" + targetAddress2 + "' that was just added to the member list by '" + conTwo.getUser() + "' (an admin) (but does not appear on the member list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -173,7 +173,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Asserts that a member list modification can be used to remove people from the member list.
+     * Asserts that a member list modification made by an admin can be used to remove people from the member list.
      */
     @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. [...] each item MUST include the 'affiliation' attribute (normally set to a value of \"member\" or \"none\")")
     public void mucTestAdminMemberListMultipleItemsRevoke() throws Exception
@@ -207,10 +207,10 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (but does appear on the member list).");
-            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (but does appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress1)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress1 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (an admin) (but does appear on the member list).");
+            assertTrue(mucAsSeenByAdmin.getMembers().stream().noneMatch(i -> i.getAffiliation() == MUCAffiliation.member && i.getJid().equals(targetAddress2)), "Expected the member list for '" + mucAddress + "' to no longer contain '" + targetAddress2 + "' that was just removed from the member list by '" + conTwo.getUser() + "' (an admin) (but does appear on the member list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -218,8 +218,8 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Asserts that a member list modification is a delta: it shouldn't affect entries already on the member list that are
-     * not included in the delta.
+     * Asserts that a member list modification made by an admin is a delta: it shouldn't affect entries already on the
+     * member list that are not included in the delta.
      */
     @SmackIntegrationTest(section = "9.5", quote = "The admin can then modify the member list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\")")
     public void mucTestAdminMemberListIsDelta() throws Exception
@@ -251,14 +251,14 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
             try {
                 conTwo.sendIqRequestAndWaitForResponse(iq);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).");
+                throw new TestNotPossibleException("Expected the service to inform '" + conTwo.getUser() + "' (an admin) of success after they modified the member list of room '" + mucAddress + "' (but instead, an error was returned).");
             }
 
             // Verify result.
             final Set<Jid> members = mucAsSeenByAdmin.getMembers().stream().filter(i -> i.getAffiliation().equals(MUCAffiliation.member)).map(Affiliate::getJid).collect(Collectors.toSet());
-            assertFalse(members.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the member list of '" + mucAddress + "', after '" + conTwo.getUser() + "' updated the member list that previously contained them with their removal (but does still appear on the member list).");
-            assertTrue(members.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the member list of '" + mucAddress + "', after the member list that previously contained them got updated by '" + conTwo.getUser() + "' with different items (which should have been applied as a delta).");
-            assertTrue(members.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the member list of '" + mucAddress + "', after the member list that previously did not contain them got updated by '" + conTwo.getUser() + "' with items that include them.");
+            assertFalse(members.contains(targetAddress1), "Expected '" + targetAddress1 + "' to no longer be on the member list of '" + mucAddress + "', after '" + conTwo.getUser() + "' (an admin) updated the member list that previously contained them with their removal (but does still appear on the member list).");
+            assertTrue(members.contains(targetAddress2), "Expected '" + targetAddress2 + "' to be on the member list of '" + mucAddress + "', after the member list that previously contained them got updated by '" + conTwo.getUser() + "' (an admin) with different items (which should have been applied as a delta).");
+            assertTrue(members.contains(targetAddress3), "Expected '" + targetAddress3 + "' to be on the member list of '" + mucAddress + "', after the member list that previously did not contain them got updated by '" + conTwo.getUser() + "' (an admin) with items that include them.");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -266,8 +266,8 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Verifies that occupants that get their membership revoked by modification of the member list are prevented
-     * from accessing the room
+     * Verifies that occupants that get their membership revoked by modification of the member list by an admin
+     * are prevented from accessing the room
      */
     @SmackIntegrationTest(section = "9.5", quote = "If a removed member is currently in a members-only room [..] The service MUST subsequently refuse entry to the user.")
     public void mucTestMemberListNoEntryAfterRevoke() throws Exception
@@ -275,21 +275,25 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-noentry");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
         final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
 
         createMembersOnlyMuc(mucAsSeenByOwner, nicknameOwner);
         try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
             mucAsSeenByOwner.grantMembership(targetAddress);
+            mucAsSeenByAdmin.join(nicknameAdmin);
 
             // Execute system under test.
-            mucAsSeenByOwner.revokeMembership(targetAddress);
+            mucAsSeenByAdmin.revokeMembership(targetAddress);
 
             // Verify result.
-            assertThrows(XMPPException.XMPPErrorException.class, () -> mucAsSeenByTarget.join(nicknameTarget), "Expected '" + conThree.getUser() + "' to receive an error when trying to join room '" + mucAddress + "' after '" + conOne.getUser() + "' removed them from the member list (but no error was received).'");
+            assertThrows(XMPPException.XMPPErrorException.class, () -> mucAsSeenByTarget.join(nicknameTarget), "Expected '" + conThree.getUser() + "' to receive an error when trying to join room '" + mucAddress + "' after '" + conTwo.getUser() + "' (an admin) removed them from the member list (but no error was received).'");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -297,7 +301,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Verifies that other occupants are notified when member list changes are made.
+     * Verifies that other occupants are notified when member list changes are made by an admin.
      */
     @SmackIntegrationTest(section = "9.5", quote = "[for a removed member] For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\".")
     public void mucTestMemberListRemainingOccupantsInformedOfRevokeOpenRoom() throws Exception
@@ -359,8 +363,8 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
             mucAsSeenByAdmin.revokeMembership(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
-            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -368,7 +372,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Verifies that other occupants are notified when member list changes are made.
+     * Verifies that other occupants are notified when member list changes are made by an admin.
      */
     @SmackIntegrationTest(section = "9.5", quote = "[for a removed member] For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\".")
     public void mucTestMemberListRemainingOccupantsInformedOfRevokeMemberOnlyRoom() throws Exception
@@ -417,10 +421,10 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
             mucAsSeenByAdmin.revokeMembership(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            final Presence ownerReceivedPresence = assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
-            final Presence adminReceivedPresence = assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
-            assertTrue(ownerReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conOne.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' revoking their membership (but it was not).");
-            assertTrue(adminReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' revoking their membership (but it was not).");
+            final Presence ownerReceivedPresence = assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
+            final Presence adminReceivedPresence = assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"none\" for '" + targetAddress1 + "' after its membership was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be a member-only room (but no such stanza was received).");
+            assertTrue(ownerReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conOne.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' (an admin) revoking their membership (but it was not).");
+            assertTrue(adminReceivedPresence.getExtension(MUCUser.class).getItem() != null && ownerReceivedPresence.getExtension(MUCUser.class).getItem().getAffiliation().equals(MUCAffiliation.none), "Expected to find an item with affiliation 'none' in the presence stanza received by '" + conTwo.getUser() + "' when '" + conThree.getUser() + "' was removed from members-only room '" + mucAddress + "' as a result of '" + conTwo.getUser() + "' (an admin) revoking their membership (but it was not).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -428,25 +432,30 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Verifies that sending an invitation in an open room does not automatically add the invitee to the member list.
+     * Verifies that sending an invitation (by an admin) in an open room does not automatically add the invitee to the member list.
      */
     @SmackIntegrationTest(section = "9.5", quote = "Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.")
-    public void mucTestMemberListNoChangeWithInviteInOpenROom() throws Exception
+    public void mucTestMemberListNoChangeWithInviteInOpenRoom() throws Exception
     {
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-invite-open");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
 
         final EntityBareJid targetAddress = conThree.getUser().asEntityBareJid();
 
         createMuc(mucAsSeenByOwner, nicknameOwner);
         try {
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByAdmin.join(nicknameAdmin);
+
             // Execute system under test.
-            mucAsSeenByOwner.invite(targetAddress, "Invitation as part of an integration test.");
+            mucAsSeenByAdmin.invite(targetAddress, "Invitation as part of an integration test.");
 
             // Verify result.
-            assertFalse(mucAsSeenByOwner.getMembers().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Did not expect '" + targetAddress + "' to be on the member list of open room '" + mucAddress + "' after they were invited by '" + conOne.getUser() + "' (but they are on the member list).");
+            assertFalse(mucAsSeenByOwner.getMembers().stream().anyMatch(i -> i.getJid().equals(targetAddress)), "Did not expect '" + targetAddress + "' to be on the member list of open room '" + mucAddress + "' after they were invited by '" + conTwo.getUser() + "' (an admin) (but they are on the member list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -454,7 +463,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     }
 
     /**
-     * Verifies that other occupants are notified when member list changes are made.
+     * Verifies that other occupants are notified when member list changes are made by an admin.
      */
     @SmackIntegrationTest(section = "9.5", quote = "If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\".")
     public void mucTestMemberListOccupantsInformedOfGrantOpenRoom() throws Exception
@@ -521,13 +530,12 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
             mucAsSeenByAdmin.grantMembership(List.of(targetAddress1, targetAddress2));
 
             // Verify result.
-            assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
-            assertResult(adminSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
-            assertResult(target1SeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(ownerSeesGrant, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(adminSeesGrant, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
+            assertResult(target1SeesGrant, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the change in affiliation by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'affiliation' attribute set to a value of \"member\" for '" + targetAddress1 + "' after its membership was granted by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' which is configured to be an open room (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
         }
     }
-
 }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -52,9 +52,9 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Asserts that a moderator list can be obtained.
+     * Asserts that a moderator list can be obtained by an admin.
      */
-    @SmackIntegrationTest(section = "9.8", quote = " the admin [...] requests the moderator list by querying the room for all users with a role of 'moderator'.")
+    @SmackIntegrationTest(section = "9.8", quote = "the admin [...] requests the moderator list by querying the room for all users with a role of 'moderator'.")
     public void mucTestAdminRequestsModeratorList() throws Exception
     {
         // Setup test fixture.
@@ -79,7 +79,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
 
             // Verify result.
         } catch (XMPPException.XMPPErrorException e) {
-            fail("Expected admin '" + conTwo.getUser() + "' to be able to receive the moderator list from '" + mucAddress + "' (but the server returned an error).", e);
+            fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to receive the moderator list from '" + mucAddress + "' (but the server returned an error).", e);
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -87,9 +87,9 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Asserts that a moderator list item has 'nick' and 'role' attributes.
+     * Asserts that a moderator list item (as requested by an admin) has 'nick' and 'role' attributes.
      */
-    @SmackIntegrationTest(section = "9.8", quote = "each item MUST include the 'nick' and 'role' attributes")
+    @SmackIntegrationTest(section = "9.8", quote = "The service MUST then return the moderator list to the admin; each item MUST include the 'nick' and 'role' attributes")
     public void mucTestAdminModeratorListItemCheck() throws Exception
     {
         // Setup test fixture.
@@ -124,7 +124,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
             try {
                 mucAsSeenByAdmin.grantModerator(nicknameTarget);
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Expected admin '" + conTwo.getUser() + "' to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
+                throw new TestNotPossibleException("Expected '" + conTwo.getUser() + "' (an admin) to be able to grant moderator status to '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).");
             }
 
             // Execute system under test.
@@ -135,8 +135,8 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
             final MUCAdmin response = conTwo.sendIqRequestAndWaitForResponse(iq);
 
             // Verify result.
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getNick() == null), "The moderator list for '" + mucAddress + "' contains an item that does not have a 'nick' attribute (but all items must have one).");
-            assertFalse(response.getItems().stream().anyMatch(i -> i.getRole() == null), "The moderator list for '" + mucAddress + "' contains an item that does not have a 'role' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getNick() == null), "The moderator list for '" + mucAddress + "' as requested by '" +  conTwo.getUser() + "' (an admin) contains an item that does not have a 'nick' attribute (but all items must have one).");
+            assertFalse(response.getItems().stream().anyMatch(i -> i.getRole() == null), "The moderator list for '" + mucAddress + "' as requested by '" +  conTwo.getUser() + "' (an admin) contains an item that does not have a 'role' attribute (but all items must have one).");
             assertTrue(response.getItems().stream().anyMatch(i -> i.getNick().equals(nicknameTarget)), "Expected the moderator list requested by '" + conTwo.getUser() + "' from '" + mucAddress + "' to include '" + nicknameTarget + "' (but it did not).");
         } finally {
             // Tear down test fixture.
@@ -146,6 +146,13 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
 
     /**
      * Asserts that a moderator list modification can contain more than one item.
+     *
+     * The specification under test defines that a user with the affiliation of 'admin' performs the action that is being
+     * tested here. As the test framework does not allow for more than three users to be used, we are one user short for
+     * this to happen (the user that created the chatroom is an owner by definition. For a multi-item change, both other
+     * users are needed). For this reason, the 'actor' in the implementation of this test is the room owner (the XEP
+     * defines that "an owner can do anything an admin can do" in section 5.2.1). This compromise (not using an admin
+     * user but an owner user) does allow for a test of a Moderator List modification that contains more than one item.
      */
     @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. In order to do so, the admin MUST send the changed items [...] back to the service [...] The service MUST modify the moderator list and then inform the admin of success")
     public void mucTestAdminModeratorListMultipleItems() throws Exception
@@ -208,8 +215,8 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
             } catch (XMPPException.XMPPErrorException e) {
                 fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget1 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (but does not appear on the moderator list).");
-            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget2 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (but does not appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget1 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (an owner) (but does not appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().anyMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to contain '" + nicknameTarget2 + "' that was just added to the moderator list by '" + conOne.getUser() + "' (an owner) (but does not appear on the moderator list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -217,7 +224,14 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Asserts that a moderator list modification can be used to remove people from the moderator list.
+     * Asserts that a moderator list modification made by can be used to remove people from the moderator list.
+     *
+     * The specification under test defines that a user with the affiliation of 'admin' performs the action that is being
+     * tested here. As the test framework does not allow for more than three users to be used, we are one user short for
+     * this to happen (the user that created the chatroom is an owner by definition. For a multi-item change, both other
+     * users are needed). For this reason, the 'actor' in the implementation of this test is the room owner (the XEP
+     * defines that "an owner can do anything an admin can do" in section 5.2.1). This compromise (not using an admin
+     * user but an owner user) does allow for a test of a Moderator List modification that contains more than one item.
      */
     @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. [...] set to a value of \"moderator\" to grant moderator status or \"participant\" to revoke moderator status)")
     public void mucTestAdminModeratorListMultipleItemsRevoke() throws Exception
@@ -269,7 +283,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
             try {
                 mucAsSeenByOwner.grantModerator(List.of(nicknameTarget1, nicknameTarget2));
             } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' and/or '" + conThree + "' the moderator role in room '" + mucAddress + "'.");
+                throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' and/or '" + conThree.getUser() + "' the moderator role in room '" + mucAddress + "'.");
             }
 
             // Execute system under test.
@@ -284,10 +298,10 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conOne.getUser() + "' (an owner) of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
-            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget1 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (but does appear on the moderator list).");
-            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget2 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (but does appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget1)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget1 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (an owner) (but does appear on the moderator list).");
+            assertTrue(mucAsSeenByOwner.getModerators().stream().noneMatch(i -> i.getRole() == MUCRole.moderator && i.getNick().equals(nicknameTarget2)), "Expected the moderator list for '" + mucAddress + "' to no longer contain '" + nicknameTarget2 + "' that was just removed from the moderator list by '" + conOne.getUser() + "' (an owner) (but does appear on the moderator list).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -297,6 +311,13 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     /**
      * Asserts that a moderator list modification is a delta: it shouldn't affect entries already on the moderator list
      * that are not included in the delta.
+     *
+     * The specification under test defines that a user with the affiliation of 'admin' performs the action that is being
+     * tested here. As the test framework does not allow for more than three users to be used, we are one user short for
+     * this to happen (the user that created the chatroom is an owner by definition. For a multi-item change, both other
+     * users are needed). For this reason, the 'actor' in the implementation of this test is the room owner (the XEP
+     * defines that "an owner can do anything an admin can do" in section 5.2.1). This compromise (not using an admin
+     * user but an owner user) does allow for a test of a Moderator List modification that contains more than one item.
      */
     @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list if desired. In order to do so, the admin MUST send the changed items (i.e., only the \"delta\")")
     public void mucTestAdminModeratorListIsDelta() throws Exception
@@ -375,7 +396,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Verifies that other occupants are notified when moderator list changes are made.
+     * Verifies that other occupants are notified when moderator list changes are made by an admin
      */
     @SmackIntegrationTest(section = "9.8", quote = "The admin can then modify the moderator list [...] The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator status by sending the appropriate extended presence stanzas")
     public void mucTestAdminModeratorListBroadcast() throws Exception
@@ -383,100 +404,76 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-        final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
-        final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-        final Resourcepart nicknameTarget1 = Resourcepart.from("target1-" + randomString);
-        final Resourcepart nicknameTarget2 = Resourcepart.from("target2-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
 
-        final EntityFullJid target1MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget1);
-        final EntityFullJid target2MucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget2);
+        final EntityFullJid adminMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameAdmin);
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
 
         createMuc(mucAsSeenByOwner, nicknameOwner);
         try {
-            try {
-                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
-                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
-                    mucAsSeenByOwner.grantModerator(nicknameOwner);
-                }
-            } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
-            }
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
 
-            final SimpleResultSyncPoint ownerSeesTarget1 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint ownerSeesTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesAdmin = new SimpleResultSyncPoint();
             mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void joined(EntityFullJid participant) {
-                    if (participant.equals(target1MucAddress)) {
-                        ownerSeesTarget1.signal();
-                    }
-                    if (participant.equals(target2MucAddress)) {
-                        ownerSeesTarget2.signal();
+                    if (participant.equals(adminMucAddress)) {
+                        ownerSeesAdmin.signal();
                     }
                 }
             });
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            ownerSeesAdmin.waitForResult(timeout);
 
-            mucAsSeenByTarget1.join(nicknameTarget1);
-            mucAsSeenByTarget2.join(nicknameTarget2);
-
-            ownerSeesTarget1.waitForResult(timeout);
-            ownerSeesTarget2.waitForResult(timeout);
+            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            ownerSeesTarget.waitForResult(timeout);
 
             try {
-                mucAsSeenByOwner.grantModerator(nicknameTarget1);
+                // Implementations _should_ give an admin the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameAdmin))) {
+                    mucAsSeenByOwner.grantModerator(nicknameAdmin);
+                }
             } catch (XMPPException.XMPPErrorException e) {
                 throw new TestNotPossibleException("Unable to grant '" + conTwo.getUser() + "' the moderator role in room '" + mucAddress + "'.");
             }
 
-            final SimpleResultSyncPoint ownerSeesRevokeTarget1 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint ownerSeesGrantTarget2 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint target1SeesRevokeTarget1 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint target1SeesGrantTarget2 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint target2SeesRevokeTarget1 = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint target2SeesGrantTarget2 = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesGrantTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint adminSeesGrantTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint targetSeesGrantTarget = new SimpleResultSyncPoint();
             mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void moderatorGranted(EntityFullJid participant) {
-                    if (participant.equals(target2MucAddress)) {
-                        ownerSeesGrantTarget2.signal();
-                    }
-                }
-
-                @Override
-                public void moderatorRevoked(EntityFullJid participant) {
-                    if (participant.equals(target1MucAddress)) {
-                        ownerSeesRevokeTarget1.signal();
+                    if (participant.equals(targetMucAddress)) {
+                        ownerSeesGrantTarget.signal();
                     }
                 }
             });
-            mucAsSeenByTarget1.addUserStatusListener(new UserStatusListener() {
-                @Override
-                public void moderatorRevoked() {
-                    target1SeesRevokeTarget1.signal();
-                }
-            });
-            mucAsSeenByTarget1.addParticipantStatusListener(new ParticipantStatusListener() {
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void moderatorGranted(EntityFullJid participant) {
-                    if (participant.equals(target2MucAddress)) {
-                        target1SeesGrantTarget2.signal();
+                    if (participant.equals(targetMucAddress)) {
+                        adminSeesGrantTarget.signal();
                     }
                 }
             });
-            mucAsSeenByTarget2.addUserStatusListener(new UserStatusListener() {
+            mucAsSeenByTarget.addUserStatusListener(new UserStatusListener() {
                 @Override
                 public void moderatorGranted() {
-                    target2SeesGrantTarget2.signal();
-                }
-            });
-            mucAsSeenByTarget2.addParticipantStatusListener(new ParticipantStatusListener() {
-                @Override
-                public void moderatorRevoked(EntityFullJid participant) {
-                    if (participant.equals(target1MucAddress)) {
-                        target2SeesRevokeTarget1.signal();
-                    }
+                    targetSeesGrantTarget.signal();
                 }
             });
 
@@ -484,23 +481,20 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
             final MUCAdmin iq = new MUCAdmin();
             iq.setTo(mucAddress);
             iq.setType(IQ.Type.set);
-            iq.addItem(new MUCItem(MUCRole.participant, nicknameTarget1));
-            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget2));
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget));
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameOwner)); // This should be fine, as it's essentially a no-op (preferably, we'd use a different occupant for this, but the testing framework only gives us 3).
 
             try {
-                conOne.sendIqRequestAndWaitForResponse(iq);
+                conTwo.sendIqRequestAndWaitForResponse(iq);
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected the service to inform '" + conOne.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
+                fail("Expected the service to inform '" + conTwo.getUser() + "' of success after they modified the moderator list of room '" + mucAddress + "' (but instead, an error was returned).", e);
             }
 
-            assertResult(ownerSeesRevokeTarget1, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget1 + "' (but did not).");
-            assertResult(ownerSeesGrantTarget2, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget2 + "' (but did not).");
-            assertResult(target1SeesRevokeTarget1, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status for themself (but did not).");
-            assertResult(target1SeesGrantTarget2, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget2 + "' (but did not).");
-            assertResult(target2SeesRevokeTarget1, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget1 + "' (but did not).");
-            assertResult(target2SeesGrantTarget2, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status for themself' (but did not).");
+            assertResult(ownerSeesGrantTarget, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget + "' by '" + conTwo.getUser() + "' (an admin) (but did not).");
+            assertResult(adminSeesGrantTarget, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status of '" + nicknameTarget + "' by '" + conTwo.getUser() + "' (an admin) (but did not).");
+            assertResult(targetSeesGrantTarget, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + mucAddress + "' indicating the change in moderator status for themself by '" + conTwo.getUser() + "' (an admin) (but did not).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -508,7 +502,11 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Verifies that an admin cannot revoke moderator status from another admin
+     * Verifies that an admin cannot revoke moderator status from another admin.
+     *
+     * This test uses a request that targets not one but two chat room occupants (the target owner and another participant)
+     * as the test intends to test the Modification of the Moderator List use-case (Using just one occupant would make
+     * the request indistinguishable from the "Granting" or "Revoking Moderator Status" use-cases).
      */
     @SmackIntegrationTest(section = "9.8", quote = "[...] moderator status cannot be revoked from a [...] room admin. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void testAdminNotAllowedToRevokeModeratorFromAdmin() throws Exception
@@ -517,56 +515,58 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-admin-rejected");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTargetAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
-        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerThree.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final Resourcepart nicknameTargetAdmin = Resourcepart.from("targetAdmin-" + randomString);
-        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
 
         final EntityFullJid targetAdminMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTargetAdmin);
-        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+        final EntityFullJid adminMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameAdmin);
 
         createMuc(mucAsSeenByOwner, nicknameOwner);
         try {
-            try {
-                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
-                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
-                    mucAsSeenByOwner.grantModerator(nicknameOwner);
-                }
-            } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
-            }
             mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
+            mucAsSeenByOwner.grantAdmin(conThree.getUser().asBareJid());
 
+            final SimpleResultSyncPoint ownerSeesAdmin = new SimpleResultSyncPoint();
             final SimpleResultSyncPoint ownerSeesTargetAdmin = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
             mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void joined(EntityFullJid participant) {
+                    if (participant.equals(adminMucAddress)) {
+                        ownerSeesAdmin.signal();
+                    }
                     if (participant.equals(targetAdminMucAddress)) {
                         ownerSeesTargetAdmin.signal();
                     }
-                    if (participant.equals(targetMucAddress)) {
-                        ownerSeesTarget.signal();
-                    }
                 }
             });
-
+            mucAsSeenByAdmin.join(nicknameAdmin);
             mucAsSeenByTargetAdmin.join(nicknameTargetAdmin);
-            mucAsSeenByTarget.join(nicknameTarget);
-
+            ownerSeesAdmin.waitForResult(timeout);
             ownerSeesTargetAdmin.waitForResult(timeout);
-            ownerSeesTarget.waitForResult(timeout);
+            try {
+                // Implementations _should_ give an admin the role of 'moderator' by default, but let's check and correct for that to be sure.
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameAdmin))) {
+                    mucAsSeenByOwner.grantModerator(nicknameAdmin);
+                }
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameTargetAdmin))) {
+                    mucAsSeenByOwner.grantModerator(nicknameTargetAdmin);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant admin '" + conTwo.getUser() + "' and/or '" + conThree.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
 
             // Execute system under test.
             final MUCAdmin iq = new MUCAdmin();
             iq.setTo(mucAddress);
             iq.setType(IQ.Type.set);
-            iq.addItem(new MUCItem(MUCRole.participant, nicknameTargetAdmin)); // Should be rejected
-            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget)); // Should be valid
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameTargetAdmin)); // Should cause the request to be rejected.
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameOwner)); // This should be fine, as it's essentially a no-op (preferably, we'd use a different occupant for this, but the testing framework only gives us 3).
 
-            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conOne.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conOne.getUser() + "' to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameTargetAdmin + "' which is an admin in room '" + mucAddress + "' (but no error was received).");
-            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameTargetAdmin + "', another admin.");
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conThree.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conThree.getUser() + "' (an admin) to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameOwner + "' that is an admin in room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conThree.getUser() + "' (an admin) after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameOwner + "', that is an admin.");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -574,7 +574,11 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     }
 
     /**
-     * Verifies that an admin cannot revoke moderator status from an owner
+     * Verifies that an admin cannot revoke moderator status from an owner.
+     *
+     * This test uses a request that targets not one but two chat room occupants (the target owner and another participant)
+     * as the test intends to test the Modification of the Moderator List use-case (Using just one occupant would make
+     * the request indistinguishable from the "Granting" or "Revoking Moderator Status" use-cases).
      */
     @SmackIntegrationTest(section = "9.8", quote = "[...] moderator status cannot be revoked from a room owner [...]. If a room admin attempts to revoke moderator status from such a user by modifying the moderator list, the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void testAdminNotAllowedToRevokeModeratorFromOwner() throws Exception
@@ -582,57 +586,62 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
         // Setup test fixture.
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-owner-rejected");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-        final MultiUserChat mucAsSeenByTargetOwner = mucManagerTwo.getMultiUserChat(mucAddress);
-        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByAdmin = mucManagerThree.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-        final Resourcepart nicknameTargetOwner = Resourcepart.from("targetOwner-" + randomString);
-        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameAdmin = Resourcepart.from("admin-" + randomString);
 
-        final EntityFullJid targetOwnerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTargetOwner);
-        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+        final EntityFullJid participantMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameParticipant);
+        final EntityFullJid adminMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameAdmin);
 
         createMuc(mucAsSeenByOwner, nicknameOwner);
         try {
-            try {
-                // Implementations _should_ give the owner the role of 'moderator' by default, but let's check and correct for that to be sure.
-                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameOwner))) {
-                    mucAsSeenByOwner.grantModerator(nicknameOwner);
-                }
-            } catch (XMPPException.XMPPErrorException e) {
-                throw new TestNotPossibleException("Unable to grant owner '" + conOne.getUser() + "' the moderator role in room '" + mucAddress + "'.");
-            }
-            mucAsSeenByOwner.grantOwnership(conTwo.getUser().asBareJid());
+            mucAsSeenByOwner.grantAdmin(conThree.getUser().asBareJid());
 
-            final SimpleResultSyncPoint ownerSeesTargetAdmin = new SimpleResultSyncPoint();
-            final SimpleResultSyncPoint ownerSeesTarget = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint ownerSeesAdmin = new SimpleResultSyncPoint();
+            // Implementations _should_ give an admin the role of 'moderator' by default, but let's check and correct for that to be sure.
             mucAsSeenByOwner.addParticipantStatusListener(new ParticipantStatusListener() {
                 @Override
                 public void joined(EntityFullJid participant) {
-                    if (participant.equals(targetOwnerMucAddress)) {
-                        ownerSeesTargetAdmin.signal();
-                    }
-                    if (participant.equals(targetMucAddress)) {
-                        ownerSeesTarget.signal();
+                    if (participant.equals(adminMucAddress)) {
+                        ownerSeesAdmin.signal();
                     }
                 }
             });
+            mucAsSeenByAdmin.join(nicknameAdmin);
+            ownerSeesAdmin.waitForResult(timeout);
+            try {
+                if (mucAsSeenByOwner.getModerators().stream().noneMatch(m -> m.getNick().equals(nicknameAdmin))) {
+                    mucAsSeenByOwner.grantModerator(nicknameAdmin);
+                }
+            } catch (XMPPException.XMPPErrorException e) {
+                throw new TestNotPossibleException("Unable to grant admin '" + conThree.getUser() + "' the moderator role in room '" + mucAddress + "'.");
+            }
 
-            mucAsSeenByTargetOwner.join(nicknameTargetOwner);
-            mucAsSeenByTarget.join(nicknameTarget);
-
-            ownerSeesTargetAdmin.waitForResult(timeout);
-            ownerSeesTarget.waitForResult(timeout);
+            // Wait for the extra target to have joined the room.
+            final SimpleResultSyncPoint adminSeesParticipant = new SimpleResultSyncPoint();
+            mucAsSeenByAdmin.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(participantMucAddress)) {
+                        adminSeesParticipant.signal();
+                    }
+                }
+            });
+            mucAsSeenByParticipant.join(nicknameParticipant);
+            adminSeesParticipant.waitForResult(timeout);
 
             // Execute system under test.
             final MUCAdmin iq = new MUCAdmin();
             iq.setTo(mucAddress);
             iq.setType(IQ.Type.set);
-            iq.addItem(new MUCItem(MUCRole.participant, nicknameTargetOwner)); // Should be rejected
-            iq.addItem(new MUCItem(MUCRole.moderator, nicknameTarget)); // Should be valid
+            iq.addItem(new MUCItem(MUCRole.participant, nicknameOwner)); // Should cause the request to be rejected.
+            iq.addItem(new MUCItem(MUCRole.moderator, nicknameParticipant)); // This should be fine.
 
-            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conOne.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conOne.getUser() + "' to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameTargetOwner + "' that is an owner in room '" + mucAddress + "' (but no error was received).");
-            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conOne.getUser() + "' after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameTargetOwner + "', that is an owner.");
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> conThree.sendIqRequestAndWaitForResponse(iq), "Expected Moderator List modification submitted by '" + conThree.getUser() + "' (an admin) to be rejected, as it illegally attempts to revoke moderator status from '" + nicknameOwner + "' that is an owner in room '" + mucAddress + "' (but no error was received).");
+            assertEquals(StanzaError.Condition.not_allowed, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conThree.getUser() + "' (an admin) after it tried to modify the moderator list of room '" + mucAddress + "' by removing moderator status of '" + nicknameOwner + "', that is an owner.");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -103,7 +103,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to revoke moderator status from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -163,7 +163,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
 
                 // Verify result.
             } catch (XMPPException.XMPPErrorException e) {
-                fail("Expected admin '" + conTwo.getUser() + "' to be able to revoke moderator status (using the optional 'reason' element) from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
+                fail("Expected '" + conTwo.getUser() + "' (an admin) to be able to revoke moderator status (using the optional 'reason' element) from '" + targetMucAddress + "' in '" + mucAddress + "' (but the server returned an error).", e);
             }
         } finally {
             // Tear down test fixture.
@@ -220,7 +220,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
             final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
                 conTwo.sendIqRequestAndWaitForResponse(request);
             }, "Expected an error after '" + conTwo.getUser() + "' (that is not an admin) tried to revoke moderator status from another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' (but none occurred).");
-            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke moderator status from another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' while not being an admin.");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (that is not an admin) after it tried to revoke moderator status from another participant ('" + targetMucAddress + "') for room '" + mucAddress + "' while not being an admin.");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -276,7 +276,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
             }
 
             // Verify result.
-            assertFalse(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to no longer be on the Moderator List after their moderator status was revoked by '" + conTwo + "' from '" + mucAddress + "' (but their nickname does appear on the Moderator List).");
+            assertFalse(mucAsSeenByAdmin.getModerators().stream().anyMatch(affiliate -> affiliate.getNick().equals(nicknameTarget)), "Expected '" + nicknameTarget + "' to no longer be on the Moderator List after their moderator status was revoked by '" + conTwo.getUser() + "' (an admin) from '" + mucAddress + "' (but their nickname does appear on the Moderator List).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);
@@ -360,9 +360,9 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
             }
 
             // Verify result.
-            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after their status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
-            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(targetSeesRevoke, "Expected '" + conThree.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after their status was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(ownerSeesRevoke, "Expected '" + conOne.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
+            assertResult(adminSeesRevoke, "Expected '" + conTwo.getUser() + "' to receive a presence stanza from '" + targetMucAddress + "' indicating the revokation of moderator status, after '" + targetMucAddress + "'s status was revoked by '" + conTwo.getUser() + "' (an admin) in '" + mucAddress + "' (but no such stanza was received).");
         } finally {
             // Tear down test fixture.
             tryDestroy(mucAsSeenByOwner);


### PR DESCRIPTION
Various tests did not explicitly use an admin user. Even when an owner technically should have all admin privileges, it is cleaner to explicitly execute the system under test with an admin user, when testing admin functionality.