### PR TITLE
Add docker testing to PR CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
   checks: write
 
 jobs:
-  build:
+  build-java:
     name: Build
     runs-on: ubuntu-latest
     strategy:
@@ -33,10 +33,10 @@ jobs:
           name: smack-tests
           path: target/smack-sint-server-extensions-*-jar-with-dependencies.jar
           retention-days: 1
-  test:
+  test-java:
     name: Test
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-java
     steps:
       - name: Checkout Openfire actions e.g. 'startCIServer'
         uses: actions/checkout@v4
@@ -114,3 +114,69 @@ jobs:
           suite_regex: '*'
           include_passed: true
           detailed_summary: true
+
+  build-and-test-docker:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          load: true
+          tags: xmpp_interop_tests:testing
+
+      - name: Checkout Openfire actions e.g. 'startCIServer'
+        uses: actions/checkout@v4
+        with:
+          repository: igniterealtime/Openfire
+          sparse-checkout: |
+            .github
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: openfire.tar.gz
+          key: openfire-${{env.OPENFIRE_VERSION}}
+      - name: Download Openfire
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          DOTTED_VERSION=$(echo ${{env.OPENFIRE_VERSION}} | tr _ .)
+          curl -L https://github.com/igniterealtime/Openfire/releases/download/v$DOTTED_VERSION/openfire_${{env.OPENFIRE_VERSION}}.tar.gz -o openfire.tar.gz
+      - name: Extract Openfire
+        run: |
+          tar -xzf openfire.tar.gz
+      - name: Start CI server from distribution
+        id: startCIServer
+        uses: ./.github/actions/startserver-action
+        with:
+          distBaseDir: './openfire'
+          domain: 'example.org'
+          ip: '127.0.0.1'
+
+      - name: Run the tests
+        run: |
+          docker run \
+            --network=host \
+            -v "$(pwd)"/xmpplogs:/logs \
+            xmpp_interop_tests:testing \
+            --domain=example.org \
+            --host=127.0.0.1 \
+            --timeout=5000 \
+            --adminAccountUsername=admin \
+            --adminAccountPassword=admin \
+            --disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest"
+        shell: bash
+
+      - name: Expose XMPP debug logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: XMPP debug logs from Docker
+          path: xmpplogs/*
+      - name: Expose Openfire logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: Openfire server logs from Docker test
+          path: openfire/logs/*


### PR DESCRIPTION
Add a build-and-test step for container builds as a test of the containerisation.
We expose some logs, but don't keep the container, nor do we publish test results - other jobs deal with the tests themselves.