### PR TITLE
Fix privilege in MUC mucTestAdminMemberListItemCheck

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -110,6 +110,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
         createMuc(mucAsSeenByOwner, nicknameOwner);
         try {
             mucAsSeenByOwner.grantMembership(targetAddress);
+            mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
             mucAsSeenByAdmin.join(nicknameAdmin);
 
             // Execute system under test.


### PR DESCRIPTION
This test asserts that items in a member list have required fields. To do so, the test retrieves a member list.

The user that is used to retreive the member list is a non-privileged user. The XEP does not mandate that such a user must be allowed to retrieve the memberlist. To prevent issues, a privileged user should be used instead. All other tests in this class do so - it appears that this test erroneously omits the grant of that privilege in the test fixture setup. This is corrected in this commit.