### PR TITLE
Fix VCard error equality check

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/xep0054/VCardTempIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0054/VCardTempIntegrationTest.java
@@ -299,7 +299,7 @@ public class VCardTempIntegrationTest extends AbstractSmackIntegrationTest
 
         if (errorNonExistingVCard == null) {
             // If this throws, then the test testForErrorWhenRecipientHasNoVCard() should have failed.
-            throw new TestNotPossibleException("Requesting a vCard from an entity did does not have a vCard unexpectedly did not result in an error.");
+            throw new TestNotPossibleException("Requesting a vCard from an entity that does not have a vCard unexpectedly did not result in an error.");
         }
 
         try {

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0054/VCardTempIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0054/VCardTempIntegrationTest.java
@@ -297,11 +297,21 @@ public class VCardTempIntegrationTest extends AbstractSmackIntegrationTest
             errorNonExistingVCard = e.getStanzaError();
         }
 
+        if (errorNonExistingVCard == null) {
+            // If this throws, then the test testForErrorWhenRecipientHasNoVCard() should have failed.
+            throw new TestNotPossibleException("Requesting a vCard from an entity did does not have a vCard unexpectedly did not result in an error.");
+        }
+
         try {
             // Execute system under test
             conOne.sendIqRequestAndWaitForResponse(requestNonExistingUser);
         } catch (XMPPException.XMPPErrorException e) {
             errorNonExistingUser = e.getStanzaError();
+        }
+
+        if (errorNonExistingUser == null) {
+            // If this throws, then the test testForErrorWhenRecipientDoesntExist() should have failed.
+            throw new TestNotPossibleException("Requesting a vCard from a non-exising error unexpectedly did not result in an error.");
         }
 
         // Verify result


### PR DESCRIPTION
When requesting a vCard from a non-existing user, an error must be returned. When requesting a vCard from a user that has no vCard, an error must also be returned.

There are two tests in our code that check the above.

There is a third definition (and we have test for that), that states that both errors must be the same.

When one of the first two tests fail, running the third test is not very useful. This commit skips that test in that case.