### PR TITLE
Fixes pubsub test: do not use optional functionality

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/pubsub/PubSubExtIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/pubsub/PubSubExtIntegrationTest.java
@@ -429,13 +429,9 @@ public class PubSubExtIntegrationTest extends AbstractSmackIntegrationTest {
         try {
             // Subscribe to the node twice, using different configuration
             final Node subscriberNode = pubSubManagerTwo.getNode(nodeName);
-            final FillableSubscribeForm formA = subscriberNode.getSubscriptionOptions(subscriber.toString()).getFillableForm();
-            formA.setDigestFrequency(1);
-            final FillableSubscribeForm formB = subscriberNode.getSubscriptionOptions(subscriber.toString()).getFillableForm();
-            formB.setDigestFrequency(2);
 
-            final Subscription subscriptionA = subscriberNode.subscribe(subscriber, formA);
-            final Subscription subscriptionB = subscriberNode.subscribe(subscriber, formB);
+            final Subscription subscriptionA = subscriberNode.subscribe(subscriber);
+            final Subscription subscriptionB = subscriberNode.subscribe(subscriber);
 
             // A poor-man's "equal"
             final String normalizedRepresentationA = subscriptionA.toXML(XmlEnvironment.EMPTY).toString();


### PR DESCRIPTION
When setting up a test fixture, do not use optional functionality that may not be supported by the server.