### PR TITLE
Leave system in predicatable state after SubscriptionTests

### DIFF
--- a/src/main/java/org/jivesoftware/smack/subscription/LowLevelSubscriptionIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smack/subscription/LowLevelSubscriptionIntegrationTest.java
@@ -69,21 +69,32 @@ public class LowLevelSubscriptionIntegrationTest extends AbstractSmackLowLevelIn
 
         conOne.disconnect();
 
-        conTwo.sendStanza(subscriptionRequest);
+        try {
+            conTwo.sendStanza(subscriptionRequest);
 
-        conOne.connect();
+            conOne.connect();
 
-        final SimpleResultSyncPoint received = new SimpleResultSyncPoint();
+            final SimpleResultSyncPoint received = new SimpleResultSyncPoint();
 
-        final StanzaFilter resultFilter = new AndFilter(
-            PresenceTypeFilter.SUBSCRIBE,
-            FromMatchesFilter.createBare(conTwo.getUser())
-        );
+            final StanzaFilter resultFilter = new AndFilter(
+                PresenceTypeFilter.SUBSCRIBE,
+                FromMatchesFilter.createBare(conTwo.getUser())
+            );
 
-        conOne.addAsyncStanzaListener(p -> received.signal(), resultFilter);
+            conOne.addAsyncStanzaListener(p -> received.signal(), resultFilter);
 
-        conOne.login();
-        assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them while they were offline by '" + conTwo.getUser() + "' (but did not).");
+            conOne.login();
+            assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them while they were offline by '" + conTwo.getUser() + "' (but did not).");
+        } finally {
+            // Clean up test fixture.
+            if (!conOne.isConnected()) {
+                conOne.connect();
+            }
+            if (!conOne.isAuthenticated()) {
+                conOne.login();
+            }
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 
     /**
@@ -112,21 +123,32 @@ public class LowLevelSubscriptionIntegrationTest extends AbstractSmackLowLevelIn
 
         conOne.disconnect();
 
-        conTwo.sendStanza(subscriptionRequest);
+        try {
+            conTwo.sendStanza(subscriptionRequest);
 
-        conOne.connect();
+            conOne.connect();
 
-        final ResultSyncPoint<Presence, ?> received = new ResultSyncPoint<>();
+            final ResultSyncPoint<Presence, ?> received = new ResultSyncPoint<>();
 
-        final StanzaFilter resultFilter = new AndFilter(
-            PresenceTypeFilter.SUBSCRIBE,
-            FromMatchesFilter.createBare(conTwo.getUser())
-        );
+            final StanzaFilter resultFilter = new AndFilter(
+                PresenceTypeFilter.SUBSCRIBE,
+                FromMatchesFilter.createBare(conTwo.getUser())
+            );
 
-        conOne.addAsyncStanzaListener(p -> received.signal((Presence) p), resultFilter);
+            conOne.addAsyncStanzaListener(p -> received.signal((Presence) p), resultFilter);
 
-        conOne.login();
-        final Presence result = assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them while they were offline by '" + conTwo.getUser() + "' (but did not).");
-        assertTrue(result.hasExtension("test", "org.example.test"), "Expected the subscription request received by '" + conOne.getUser() + "' from '" + conTwo.getUser() + "' (sent while the intended recipient was offline) to include the custom extension that was in the original request (but that extension was not received).");
+            conOne.login();
+            final Presence result = assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them while they were offline by '" + conTwo.getUser() + "' (but did not).");
+            assertTrue(result.hasExtension("test", "org.example.test"), "Expected the subscription request received by '" + conOne.getUser() + "' from '" + conTwo.getUser() + "' (sent while the intended recipient was offline) to include the custom extension that was in the original request (but that extension was not received).");
+        } finally {
+            // Clean up test fixture.
+            if (!conOne.isConnected()) {
+                conOne.connect();
+            }
+            if (!conOne.isAuthenticated()) {
+                conOne.login();
+            }
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 }

--- a/src/main/java/org/jivesoftware/smack/subscription/SubscriptionIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smack/subscription/SubscriptionIntegrationTest.java
@@ -72,9 +72,14 @@ public class SubscriptionIntegrationTest extends AbstractSmackIntegrationTest {
 
         conOne.addAsyncStanzaListener(p -> received.signal(), resultFilter);
 
-        conTwo.sendStanza(subscriptionRequest);
+        try {
+            conTwo.sendStanza(subscriptionRequest);
 
-        assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent by '" + conTwo.getUser() + "' (but did not).");
+            assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent by '" + conTwo.getUser() + "' (but did not).");
+        } finally {
+            // Clean up test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 
     /**
@@ -105,8 +110,13 @@ public class SubscriptionIntegrationTest extends AbstractSmackIntegrationTest {
 
         conOne.addAsyncStanzaListener(p -> received.signal((Presence) p), resultFilter);
 
-        conTwo.sendStanza(subscriptionRequest);
-        final Presence result = assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them by '" + conTwo.getUser() + "' (but did not).");
-        assertTrue(result.hasExtension("test", "org.example.test"), "Expected the subscription request received by '" + conOne.getUser() + "' from '" + conTwo.getUser() + "' to include the custom extension that was in the original request (but that extension was not received).");
+        try {
+            conTwo.sendStanza(subscriptionRequest);
+            final Presence result = assertResult(received, "Expected '" + conOne.getUser() + "' to receive the subscription request sent to them by '" + conTwo.getUser() + "' (but did not).");
+            assertTrue(result.hasExtension("test", "org.example.test"), "Expected the subscription request received by '" + conOne.getUser() + "' from '" + conTwo.getUser() + "' to include the custom extension that was in the original request (but that extension was not received).");
+        } finally {
+            // Clean up test fixture.
+            IntegrationTestRosterUtil.ensureBothAccountsAreNotInEachOthersRoster(conOne, conTwo);
+        }
     }
 }


### PR DESCRIPTION
When tests have finished executing, they should leave the state of the XMPP users in a consistent state. This prevents tests from having results that are affected by the exection of other tests.

The goal of this commit is to ensure that any change to subscription state that is made in the SubscriptionTests is undone.