### PR TITLE
Fix subscription requests

### DIFF
--- a/src/main/java/org/jivesoftware/smack/subscription/SubscriptionIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smack/subscription/SubscriptionIntegrationTest.java
@@ -60,7 +60,7 @@ public class SubscriptionIntegrationTest extends AbstractSmackIntegrationTest {
 
         final Presence subscriptionRequest = conTwo.getStanzaFactory().buildPresenceStanza()
                 .ofType(Presence.Type.subscribe)
-                .to(conOne.getUser())
+                .to(conOne.getUser().asBareJid())
                 .build();
 
         final SimpleResultSyncPoint received = new SimpleResultSyncPoint();
@@ -97,7 +97,7 @@ public class SubscriptionIntegrationTest extends AbstractSmackIntegrationTest {
 
         final Presence subscriptionRequest = conTwo.getStanzaFactory().buildPresenceStanza()
                 .ofType(Presence.Type.subscribe)
-                .to(conOne.getUser())
+                .to(conOne.getUser().asBareJid())
                 .addExtension(new StandardExtensionElement("test", "org.example.test"))
                 .build();
 


### PR DESCRIPTION
RFC 6120 section 3.1.1 reads:

>    When a user sends a presence subscription request to a potential
>    instant messaging and presence contact, the value of the 'to'
>    attribute MUST be a bare JID <contact@domainpart> rather than a full
>    JID <contact@domainpart/resourcepart>, since the desired result is
>    for the user to receive presence from all of the contact's resources,
>    not merely the particular resource specified in the 'to' attribute.
>    Use of bare JIDs also simplifies subscription processing, presence
>    probes, and presence notifications by the user's server and the
>    contact's server.

Some of our tests were erroneously using a full JID. That's fixed in this PR.