### PR TITLE
Update to Smack 4.5.0-beta2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           -Dsinttest.adminAccountPassword=admin \
           -Dsinttest.enabledConnections=tcp \
           -Dsinttest.dnsResolver=javax \
-          -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest" \
+          -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest,FormTest" \
           -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
           -Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory" \
           -DlogDir=logs \
@@ -165,7 +165,7 @@ jobs:
             --timeout=5000 \
             --adminAccountUsername=admin \
             --adminAccountPassword=admin \
-            --disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest"
+            --disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest,FormTest"
         shell: bash
 
       - name: Expose XMPP debug logs

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <smack.version>4.5.0-alpha4-SNAPSHOT</smack.version>
+        <smack.version>4.5.0-beta2</smack.version>
     </properties>
 
     <licenses>

--- a/src/main/java/org/jivesoftware/smackx/muc/MUCAvatarIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MUCAvatarIntegrationTest.java
@@ -24,12 +24,8 @@ import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.util.stringencoder.Base64;
 import org.jivesoftware.smackx.disco.ServiceDiscoveryManager;
-import org.jivesoftware.smackx.vcardtemp.VCardManager;
 import org.jivesoftware.smackx.vcardtemp.packet.VCard;
-import org.jivesoftware.smackx.vcardtemp.provider.VCardProvider;
 import org.jxmpp.jid.EntityBareJid;
-import org.jxmpp.jid.Jid;
-import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
@@ -83,7 +79,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             vCard.setAvatar(TINY_PNG_BASE64, "image/png");
             vCard.setTo(mucAddress);
             vCard.setType(IQ.Type.set);
-            vCard.setStanzaId();
 
             // Execute system under test.
             conOne.sendIqRequestAndWaitForResponse(vCard);
@@ -113,7 +108,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             vCard.setAvatar(TINY_PNG_BASE64, "image/png");
             vCard.setTo(muc.getRoom());
             vCard.setType(IQ.Type.set);
-            vCard.setStanzaId();
 
             conOne.sendIqRequestAndWaitForResponse(vCard);
         } catch (XMPPException.XMPPErrorException e) {
@@ -137,7 +131,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             final VCard vCard = new VCard();
             vCard.setTo(mucAddress);
             vCard.setType(IQ.Type.set);
-            vCard.setStanzaId();
 
             // Execute system under test.
             conOne.sendIqRequestAndWaitForResponse(vCard);
@@ -146,7 +139,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             final VCard request = new VCard();
             request.setTo(mucAddress);
             request.setType(IQ.Type.get);
-            request.setStanzaId();
             final VCard response = conOne.sendIqRequestAndWaitForResponse(request);
             assertNull(response.getAvatar());
         } catch (XMPPException.XMPPErrorException e) {
@@ -173,7 +165,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             final VCard request = new VCard();
             request.setTo(mucAddress);
             request.setType(IQ.Type.get);
-            request.setStanzaId();
 
             // Execute system under test.
             final VCard response = conOne.sendIqRequestAndWaitForResponse(request);
@@ -205,7 +196,6 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
             vCard.setAvatar(TINY_PNG_BASE64, "image/png");
             vCard.setTo(mucAddress);
             vCard.setType(IQ.Type.set);
-            vCard.setStanzaId();
 
             // Execute system under test.
             conOne.sendIqRequestAndWaitForResponse(vCard);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -117,7 +117,12 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
             mucAsSeenByOwner.grantAdmin(conTwo.getUser().asBareJid());
             mucAsSeenByAdmin.join(nicknameAdmin);
             try {
-                mucAsSeenByAdmin.banUser(targetAddress, "Attempt to create a ban list with a full JID (which shouldn't be possible).");
+                final MUCAdmin iq = new MUCAdmin();
+                iq.setTo(mucAddress);
+                iq.setType(IQ.Type.set);
+                final MUCItem item = new MUCItem(MUCAffiliation.outcast, targetAddress, "Attempt to create a ban list with a full JID (which shouldn't be possible).");
+                iq.addItem(item);
+                this.connection.sendIqRequestAndWaitForResponse(iq);
             } catch (XMPPException.XMPPErrorException e) {
                 throw new TestNotPossibleException("Unable to create a ban list using a full JID.");
             }

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
@@ -264,11 +264,11 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
             oneSeesThree.waitForResult(timeout);
 
             // Make 'two' a member that is an admin
-            mucAsSeenByOne.grantMembership(conTwo.getUser());
+            mucAsSeenByOne.grantMembership(conTwo.getUser().asBareJid());
             mucAsSeenByOne.grantModerator(nicknameTwo);
 
             // Make 'three' an admin
-            mucAsSeenByOne.grantAdmin(conThree.getUser());
+            mucAsSeenByOne.grantAdmin(conThree.getUser().asBareJid());
 
             twoSeesThree.waitForResult(timeout);
             twoGetsModerator.waitForResult(timeout);
@@ -324,7 +324,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
                 }
             });
 
-            mucAsSeenByOne.grantMembership(conTwo.getUser());
+            mucAsSeenByOne.grantMembership(conTwo.getUser().asBareJid());
             mucAsSeenByOne.grantModerator(nicknameTwo);
 
             twoGetsModerator.waitForResult(timeout);
@@ -379,7 +379,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
                 }
             });
 
-            mucAsSeenByOne.grantAdmin(conTwo.getUser());
+            mucAsSeenByOne.grantAdmin(conTwo.getUser().asBareJid());
             mucAsSeenByOne.grantModerator(nicknameTwo);
 
             twoGetsModerator.waitForResult(timeout);


### PR DESCRIPTION
The new Smack beta has dropped some old API. This commit adjusts our code accordingly.

Sadly, one of the tests that ship with Smack now fail (see https://github.com/igniterealtime/Smack/pull/630 ). That test has been disabled in the CI for this project.