### PR TITLE
Update to Smack 4.5.0-beta3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
           -Dsinttest.adminAccountPassword=admin \
           -Dsinttest.enabledConnections=tcp \
           -Dsinttest.dnsResolver=javax \
-          -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest,FormTest" \
+          -Dsinttest.disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest" \
           -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
           -Dsinttest.debugger="org.igniterealtime.smack.inttest.util.FileLoggerFactory" \
           -DlogDir=logs \
@@ -176,7 +176,7 @@ jobs:
             --timeout=5000 \
             --adminAccountUsername=admin \
             --adminAccountPassword=admin \
-            --disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest,FormTest"
+            --disabledTests="EntityCapsTest,SoftwareInfoIntegrationTest,XmppConnectionIntegrationTest,StreamManagementTest,WaitForClosingStreamElementTest,IoTControlIntegrationTest,ModularXmppClientToServerConnectionLowLevelIntegrationTest,ServiceDiscoveryIntegrationTest,MultiUserChatOccupantPMIntegrationTest"
         shell: bash
 
       - name: Expose XMPP debug logs

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <smack.version>4.5.0-beta2</smack.version>
+        <smack.version>4.5.0-beta3</smack.version>
     </properties>
 
     <licenses>


### PR DESCRIPTION
beta3 includes a major change in Smack's build system, which also updates its minimum Java requirement from 8 to 11 (we were already using 11), and fixes the bug in the FormTest that was recently introduced.