### PR TITLE
Increase coverage of XEP-0045 to version 1.35.1

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#ban">XEP-0045 Section 9.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyban">XEP-0045 Section 9.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmember">XEP-0045 Section 9.3</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantMemberIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmod">XEP-0045 Section 9.6</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymember">XEP-0045 Section 9.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminMemberListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymod">XEP-0045 Section 9.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminModeratorListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemember">XEP-0045 Section 9.4</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeMemberIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemod">XEP-0045 Section 9.7</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#invite">XEP-0045 Section 7.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatInvitationIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatInvitationIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#kick">XEP-0045 Section 8.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatModeratorKickIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -211,7 +211,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
      */
     @SmackIntegrationTest(section = "8.2", quote =
         "A user cannot be kicked by a moderator with a lower affiliation. Therefore, if a moderator who is a member " +
-        "attempts to kick an admin [...], the service MUST deny the request and return a <not-allowed/> error to the sender")
+        "attempts to kick an admin, [...] the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void mucTestModeratorMemberCannotKickAdmin() throws Exception
     {
         final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-member-cannot-kick-admin");

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#subject-mod">XEP-0045 Section 8.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatModeratorSubjectModIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
@@ -25,7 +25,10 @@ import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.StanzaListener;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.filter.*;
-import org.jivesoftware.smack.packet.*;
+import org.jivesoftware.smack.packet.Message;
+import org.jivesoftware.smack.packet.MessageBuilder;
+import org.jivesoftware.smack.packet.Stanza;
+import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smackx.muc.packet.MUCUser;
 import org.jivesoftware.smackx.xdata.form.FillableForm;
 import org.jivesoftware.smackx.xdata.form.Form;
@@ -35,14 +38,14 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for section "7.5 Occupant Use Cases: Sending a Private Message" of XEP-0045: "Multi-User Chat"
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#privatemessage">XEP-0045 Section 7.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOccupantPMIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyadmin">XEP-0045 Section 10.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerAdminListIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -106,7 +106,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender in semi-anonymous rooms.")
     public void testUserRequestsAdminList() throws Exception
     {
         // Setup test fixture.
@@ -138,7 +138,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "[T]he owner [...] requests the admin list by querying the room for all users with an affiliation of 'admin'. [...] If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender in semi-anonymous rooms.")
     public void testParticipantRequestsAdminList() throws Exception
     {
         // Setup test fixture.
@@ -334,7 +334,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an admin (non-owner) cannot make an admin list modification.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
     public void testAdminListRejectAdmin() throws Exception
     {
         // Setup test fixture.
@@ -371,7 +371,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that a member (non-owner) cannot make an admin list modification.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
     public void testAdminListRejectMember() throws Exception
     {
         // Setup test fixture.
@@ -408,7 +408,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an outcast (non-owner) cannot make an admin list modification.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
     public void testAdminListRejectOutcast() throws Exception
     {
         // Setup test fixture.
@@ -442,7 +442,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that a user without an affiliation (non-owner) cannot make an admin list modification.
      */
-    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.8", quote = "Only owners shall be allowed to modify the admin list. If a non-owner attempts to modify the admin list, the service MUST deny the request and return a <forbidden/> error to the sender.")
     public void testAdminListRejectNoneAffiliation() throws Exception
     {
         // Setup test fixture.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#roomconfig">XEP-0045 Section 10.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerConfigRoomIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#createroom">XEP-0045 Section 10.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerCreateRoomIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#destroyroom">XEP-0045 Section 10.9</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerDestroyRoomIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -326,7 +326,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
      * Verifies that a room destruction request causes all occupants to be removed, receiving a notification that contains
      * all optional data.
      */
-    @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.")
+    @SmackIntegrationTest(section = "10.9", quote = "The service is responsible for removing all the occupants. [...] sending only one presence stanza of type \"unavailable\" to each occupant so that the user knows he or she has been removed from the room. [...] If extended presence information specifying the JID of an alternate location and/or the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.")
     public void testPresenceOptional() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TimeoutException
     {
         // Setup test fixture.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
@@ -23,6 +23,7 @@ import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smackx.muc.packet.MUCAdmin;
 import org.jivesoftware.smackx.muc.packet.MUCItem;
 import org.jxmpp.jid.EntityBareJid;
@@ -31,15 +32,14 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for section "10.6 Owner Use Cases: Granting Admin Status" of XEP-0045: "Multi-User Chat"
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantadmin">XEP-0045 Section 10.6</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerGrantAdminIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -313,158 +313,157 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
         }
     }
 
-    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict granting of admin as something only owners can do.
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToGrantAdminStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToGrantAdminStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToGrantAdminStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToGrantAdminStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToGrantAdminStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner, non-joined user cannot grant someone admin status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToGrantAdminStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToGrantAdminStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot grant someone admin status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.6", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToGrantAdminStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            participantSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid(), "Granting Admin Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant admin status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant admin status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that a (bare) JID that is granted admin status by an owner appears on the Admin List.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
@@ -23,6 +23,7 @@ import org.igniterealtime.smack.inttest.util.SimpleResultSyncPoint;
 import org.jivesoftware.smack.SmackException;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smack.packet.IQ;
+import org.jivesoftware.smack.packet.StanzaError;
 import org.jivesoftware.smackx.muc.packet.MUCAdmin;
 import org.jivesoftware.smackx.muc.packet.MUCItem;
 import org.jxmpp.jid.EntityBareJid;
@@ -31,15 +32,14 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for section "10.3 Owner Use Cases: Granting Owner Status" of XEP-0045: "Multi-User Chat"
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantowner">XEP-0045 Section 10.3</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerGrantOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -222,158 +222,157 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
         }
     }
 
-    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict granting of owner status to owners.
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToGrantOwnerStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToGrantOwnerStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToGrantOwnerStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToGrantOwnerStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            // Execute system under test.
-//            final MUCAdmin request = new MUCAdmin();
-//            request.setTo(mucAddress);
-//            request.setType(IQ.Type.set);
-//            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(request);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToGrantOwnerStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner, non-joined user cannot grant someone owner status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToGrantOwnerStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToGrantOwnerStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot grant someone owner status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.3", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToGrantOwnerStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            participantSeesTarget.waitForResult(timeout);
+
+            // Execute system under test.
+            final MUCAdmin request = new MUCAdmin();
+            request.setTo(mucAddress);
+            request.setType(IQ.Type.set);
+            request.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid(), "Granting Owner Status as part of an integration test."));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(request);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to grant owner status to another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to grant owner status to user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that a (bare) JID that is granted owner status by an owner appears on the Owner List.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#owner">XEP-0045 Section 10</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyowner">XEP-0045 Section 10.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerOwnerListIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -103,7 +103,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender in semi-anonymous rooms.")
     public void testUserRequestsOwnerList() throws Exception
     {
         // Setup test fixture.
@@ -135,7 +135,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
      *
      * This test uses a semi-anonymous room, as a XEP update is in the works that allows these requests for non-anonymous rooms.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    @SmackIntegrationTest(section = "10.5", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender in semi-anonymous rooms.")
     public void testParticipantRequestsOwnerList() throws Exception
     {
         // Setup test fixture.
@@ -326,7 +326,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an admin (non-owner) cannot make an owner list modification.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
     public void testOwnerListRejectAdmin() throws Exception
     {
         // Setup test fixture.
@@ -363,7 +363,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that a member (non-owner) cannot make an owner list modification.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
     public void testOwnerListRejectMember() throws Exception
     {
         // Setup test fixture.
@@ -400,7 +400,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that an outcast (non-owner) cannot make an owner list modification.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
     public void testOwnerListRejectOutcast() throws Exception
     {
         // Setup test fixture.
@@ -434,7 +434,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     /**
      * Asserts that a user without an affiliation (non-owner) cannot make an owner list modification.
      */
-    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
+    @SmackIntegrationTest(section = "10.5", quote = "Only owners shall be allowed to modify the owner list. If a non-owner attempts to modify the owner list, the service MUST deny the request and return a <forbidden/> error to the sender")
     public void testOwnerListRejectNoneAffiliation() throws Exception
     {
         // Setup test fixture.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
@@ -32,15 +32,14 @@ import org.jxmpp.jid.impl.JidCreate;
 import org.jxmpp.jid.parts.Resourcepart;
 import org.jxmpp.stringprep.XmppStringprepException;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests for section "10.7 Owner Use Cases: Revoking Admin Status" of XEP-0045: "Multi-User Chat"
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeadmin">XEP-0045 Section 10.7</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerRevokeAdminIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -257,186 +256,185 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
         }
     }
 
-    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict revokation of admin status to owners.
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToRevokeAdminStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToRevokeAdminStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToRevokeAdminStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToRevokeAdminStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToRevokeAdminStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner, non-joined user cannot revoke someone's admin status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToRevokeAdminStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToRevokeAdminStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot revoke someone's admin status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.7", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToRevokeAdminStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            participantSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.admin, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke admin status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke admin status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that an admin that got its admin status removed no longer exists on the admin list.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeowner">XEP-0045 Section 10.4</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.34.6")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerRevokeOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)
@@ -257,186 +257,185 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
         }
     }
 
-    // TODO enable these tests after https://github.com/xsf/xeps/pull/1370 gets merged. Until then, the specification does not seem to restrict revokation of owner status to owners.
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToRevokeOwnerStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testUserNotAllowedToRevokeOwnerStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByTarget.join(nicknameTarget);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is not in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToRevokeOwnerStatus() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
-//
-//    /**
-//     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is in the room).
-//     */
-//    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
-//    public void testParticipantNotAllowedToRevokeOwnerStatusInRoom() throws Exception
-//    {
-//        // Setup test fixture.
-//        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed-inroom");
-//        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
-//        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
-//
-//        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
-//        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
-//        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
-//
-//        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
-//
-//        createMuc(mucAsSeenByOwner, nicknameOwner);
-//        try {
-//            mucAsSeenByParticipant.join(nicknameParticipant);
-//
-//            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
-//            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
-//                @Override
-//                public void joined(EntityFullJid participant) {
-//                    if (participant.equals(targetMucAddress)) {
-//                        participantSeesTarget.signal();
-//                    }
-//                }
-//            });
-//            mucAsSeenByTarget.join(nicknameTarget);
-//            participantSeesTarget.waitForResult(timeout);
-//
-//            final MUCAdmin grantRequest = new MUCAdmin();
-//            grantRequest.setTo(mucAddress);
-//            grantRequest.setType(IQ.Type.set);
-//            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
-//
-//            conOne.sendIqRequestAndWaitForResponse(grantRequest);
-//
-//            // Execute system under test.
-//            final MUCAdmin revokeRequest = new MUCAdmin();
-//            revokeRequest.setTo(mucAddress);
-//            revokeRequest.setType(IQ.Type.set);
-//            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
-//
-//            // Verify result.
-//            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
-//                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
-//            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
-//            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
-//        } finally {
-//            // Tear down test fixture.
-//            tryDestroy(mucAsSeenByOwner);
-//        }
-//    }
+    /**
+     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToRevokeOwnerStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner, non-joined user cannot revoke someone's owner status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testUserNotAllowedToRevokeOwnerStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByTarget.join(nicknameTarget);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner) tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is not in the room).
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToRevokeOwnerStatus() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
+
+    /**
+     * Verifies that a non-owner (that has joined the room) cannot revoke someone's owner status (when the target is in the room).
+     */
+    @SmackIntegrationTest(section = "10.4", quote = "If the <user@host> of the 'from' address does not match the bare JID of a room owner, the service MUST return a <forbidden/> error to the sender.")
+    public void testParticipantNotAllowedToRevokeOwnerStatusInRoom() throws Exception
+    {
+        // Setup test fixture.
+        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed-inroom");
+        final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
+        final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
+
+        final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
+        final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
+        final Resourcepart nicknameTarget = Resourcepart.from("target-" + randomString);
+
+        final EntityFullJid targetMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameTarget);
+
+        createMuc(mucAsSeenByOwner, nicknameOwner);
+        try {
+            mucAsSeenByParticipant.join(nicknameParticipant);
+
+            final SimpleResultSyncPoint participantSeesTarget = new SimpleResultSyncPoint();
+            mucAsSeenByParticipant.addParticipantStatusListener(new ParticipantStatusListener() {
+                @Override
+                public void joined(EntityFullJid participant) {
+                    if (participant.equals(targetMucAddress)) {
+                        participantSeesTarget.signal();
+                    }
+                }
+            });
+            mucAsSeenByTarget.join(nicknameTarget);
+            participantSeesTarget.waitForResult(timeout);
+
+            final MUCAdmin grantRequest = new MUCAdmin();
+            grantRequest.setTo(mucAddress);
+            grantRequest.setType(IQ.Type.set);
+            grantRequest.addItem(new MUCItem(MUCAffiliation.owner, conThree.getUser().asBareJid()));
+
+            conOne.sendIqRequestAndWaitForResponse(grantRequest);
+
+            // Execute system under test.
+            final MUCAdmin revokeRequest = new MUCAdmin();
+            revokeRequest.setTo(mucAddress);
+            revokeRequest.setType(IQ.Type.set);
+            revokeRequest.addItem(new MUCItem(MUCAffiliation.none, conThree.getUser().asBareJid()));
+
+            // Verify result.
+            final XMPPException.XMPPErrorException e = assertThrows(XMPPException.XMPPErrorException.class, () -> {
+                conTwo.sendIqRequestAndWaitForResponse(revokeRequest);
+            }, "Expected an error after '" + conTwo.getUser() + "' (that is not an owner, but joined the room as '" + nicknameParticipant + "') tried to revoke owner status from another user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' (but none occurred).");
+            assertEquals(StanzaError.Condition.forbidden, e.getStanzaError().getCondition(), "Unexpected error condition in the (expected) error that was returned to '" + conTwo.getUser() + "' (joined as '" + nicknameParticipant + "') after it tried to revoke owner status from user ('" + conThree.getUser().asBareJid() + "', joined as '" + nicknameTarget + "') in room '" + mucAddress + "' while not being an owner.");
+        } finally {
+            // Tear down test fixture.
+            tryDestroy(mucAsSeenByOwner);
+        }
+    }
 
     /**
      * Verifies that an owner cannot revoke its own owner status when they're the last owner of the room.

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
@@ -33,14 +33,14 @@ import org.jxmpp.stringprep.XmppStringprepException;
 
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for section 14 "Security Considerations" of XEP-0045: "Multi-User Chat"
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#security">XEP-0045 Section 10</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.0")
+@SpecificationReference(document = "XEP-0045", version = "1.35.1")
 public class MultiUserChatSecurityConsiderationsIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatSecurityConsiderationsIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException


### PR DESCRIPTION
XEP-0045 version 1.35.1 was recently released by the XSF. This includes some improvements that we had suggested.

This commit updates the MUC tests to that version, which includes the bumping of the version identifier, modifications of modified texts, and the uncommenting of tests that we had already implemented in anticipation of this update.