### PR TITLE
Release Automation: Trigger Downstream Repos

### DIFF
--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -10,8 +10,10 @@ on:
         required: true
 
 jobs:
-  build:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - id: version
@@ -24,7 +26,11 @@ jobs:
                 echo "Version: ${{ github.event.release.tag_name }}"
                 echo "::set-output name=version::${{ github.event.release.tag_name }}"
             fi
-      
+
+  github-actions:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
       - name: Call downstream job for GitHub Actions
         run: |
             curl -L \
@@ -33,4 +39,4 @@ jobs:
                 -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_ACTION_REPO }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-action/dispatches \
-                -d '{"event_type":"make-pr","client_payload":{"version":${{ steps.version.outputs.version }}}}'
+                -d '{"event_type":"make-pr","client_payload":{"version":${{ needs.prepare.outputs.version }}}}'

--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -39,4 +39,7 @@ jobs:
                 -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_ACTION_REPO }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-action/dispatches \
-                -d '{"event_type":"make-pr","client_payload":{"version":${{ needs.prepare.outputs.version }}}}'
+                -d '{\
+                    "event_type":"trigger-workflow",\
+                    "client_payload":{"version":${{ needs.prepare.outputs.version }}}\
+                }'

--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -1,0 +1,36 @@
+name: Trigger Downstream Releases
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to trigger, e.g. v1.2.3'
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: version
+        name: Calculate version to trigger
+        run: |
+            if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
+                echo "Version: ${{ github.event.inputs.version }}"
+                echo "::set-output name=version::${{ github.event.inputs.version }}"
+            else
+                echo "Version: ${{ github.event.release.tag_name }}"
+                echo "::set-output name=version::${{ github.event.release.tag_name }}"
+            fi
+      
+      - name: Call downstream job for GitHub Actions
+        run: |
+            curl -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_ACTION_REPO }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-action/dispatches \
+                -d '{"event_type":"make-pr","client_payload":{"version":${{ steps.version.outputs.version }}}}'


### PR DESCRIPTION
Adds a job that triggers either manually or when a release is published.

Right now, this just makes a call to a waiting action in XMPP-Interop-Testing/xmpp-interop-tests-action (but sets up the parallelism for this to run against more).

Corresponding PR in the downstream repo: https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-action/pull/21

I've intentionally created a fine-grained PAT that covers only this repo in the secret.

![image](https://github.com/user-attachments/assets/6be1e610-33f0-4cf9-8011-dd65e72773fa)

I decided that it was less cognitive load to have 
- 1 fine-grained token per downstream target repository
rather than 
- 1 fine-grained token for all GitHub things that required updating each time we add a new CI target
- 1 token for GitLab
- 1 more for each additional non-GitHub code host