### PR TITLE
Fix downstream-triggering action

### DIFF
--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -39,7 +39,4 @@ jobs:
                 -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_ACTION_REPO }}" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-action/dispatches \
-                -d '{\
-                    "event_type":"trigger-workflow",\
-                    "client_payload":{"version":${{ needs.prepare.outputs.version }}}\
-                }'
+                -d '{"event_type":"trigger-workflow","client_payload":{"version":"${{ needs.prepare.outputs.version }}"}}'

--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -21,10 +21,10 @@ jobs:
         run: |
             if [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
                 echo "Version: ${{ github.event.inputs.version }}"
-                echo "::set-output name=version::${{ github.event.inputs.version }}"
+                echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             else
                 echo "Version: ${{ github.event.release.tag_name }}"
-                echo "::set-output name=version::${{ github.event.release.tag_name }}"
+                echo "version=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
             fi
 
   github-actions:


### PR DESCRIPTION
Fixes 2 problems.

**Problem 1:**

Use of the action gave the following error when calling the GitHub API:

```
{
  "message": "Problems parsing JSON",
  "documentation_url": "https://docs.github.com/rest/repos/repos#create-a-repository-dispatch-event",
  "status": "400"
}
```

**Problem 2:**

Running the action gave a warning about use of `::set-output`

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.