### PR TITLE
Add triggering of automated update PRs for Circle CI orb

### DIFF
--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -40,3 +40,17 @@ jobs:
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-action/dispatches \
                 -d '{"event_type":"trigger-workflow","client_payload":{"version":"${{ needs.prepare.outputs.version }}"}}'
+  
+  circle-ci-orb:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Call downstream job for Circle CI Orb
+        run: |
+            curl -L \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_ORB_REPO }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/dispatches \
+                -d '{"event_type":"trigger-workflow","client_payload":{"version":"${{ needs.prepare.outputs.version }}"}}'


### PR DESCRIPTION
When this repo has a release published, a PR will be opened on the Circle CI Orb repo.

Follows #71. I've added a GitHub PAT specific to the Orb repo to the config of this repo.

This branch was intended to do all of them, but:
* Woodpecker is still nascent
* Docker is homed here
* Bamboo isn't necessary - it takes a separate JAR
* GitLab is TODO - it's significantly harder, and would require careful use of curl requests to their API (but I've added a GitLab Pipeline Trigger token just in case)