### PR TITLE
Fix count of 'impossible' test aggregate

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/util/StdOutTestRunResultProcessor.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/util/StdOutTestRunResultProcessor.java
@@ -83,7 +83,7 @@ public class StdOutTestRunResultProcessor implements SmackIntegrationTestFramewo
                 final String title = (entry.getKey().isEmpty() ? "(noname)" : entry.getKey());
                 final Map<String, Long> reasonCount = entry.getValue().stream().collect(Collectors.groupingBy(t -> t.testNotPossibleException.getMessage(), Collectors.counting()));
                 for (final Map.Entry<String, Long> reasonEntry : reasonCount.entrySet()) {
-                    System.out.println("• " + title + ": could not run " + entry.getValue().size() + " test(s) because: " + reasonEntry.getKey());
+                    System.out.println("• " + title + ": could not run " + reasonEntry.getValue() + " test(s) because: " + reasonEntry.getKey());
                 }
             }
             for (final Map.Entry<String, Collection<Class<? extends AbstractSmackIntTest>>> entry : impossibleTestClassesBySpec.entrySet()) {


### PR DESCRIPTION
The aggregation of reasons why tests were impossible to run used the same count for all reasons.

This commit fixes:

```
Results aggregated by specification:
• RFC6121: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging ... 36 ✔  0 💀   7 ✖

✖ The following tests were impossible to run! ✖
• RFC6121: could not run 7 test(s) because: The test implementation requires the connection used for testing to not have sent initial presence (but current configuration causes initial presence to be sent automatically).
• RFC6121: could not run 7 test(s) because: Smack was unable to parse the data sent by the server: <item xmlns='jabber:iq:roster' jid='test-target-67ut7@example.org' subscription='foobar'/></query><error xmlns='jabber:client' code='500' type='wait'><internal-server-error/></error></iq>
```

... into ...

```
Results aggregated by specification:
• RFC6121: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging ... 36 ✔  0 💀   7 ✖

✖ The following tests were impossible to run! ✖
• RFC6121: could not run 6 test(s) because: The test implementation requires the connection used for testing to not have sent initial presence (but current configuration causes initial presence to be sent automatically).
• RFC6121: could not run 1 test(s) because: Smack was unable to parse the data sent by the server: <item xmlns='jabber:iq:roster' jid='test-target-67ut7@example.org' subscription='foobar'/></query><error xmlns='jabber:client' code='500' type='wait'><internal-server-error/></error></iq>
```