### PR TITLE
Don't wrap test exceptions in RuntimeException

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_1_MessageIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_1_MessageIntegrationTest.java
@@ -66,12 +66,9 @@ public class RFC6121Section8_5_2_2_1_MessageIntegrationTest extends AbstractSmac
     }
 
     @AfterClass
-    public void tearDown() {
-        try {
-            AccountUtilities.removeNonConnectedLocalUser(environment, entityWithoutResources.getLocalpart().asUnescapedString(), "secret");
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+    public void tearDown() throws InvocationTargetException, InstantiationException, IllegalAccessException
+    {
+        AccountUtilities.removeNonConnectedLocalUser(environment, entityWithoutResources.getLocalpart().asUnescapedString(), "secret");
     }
 
     // 'normal' and 'chat' types have a specification that is defined as a SHOULD (as opposed to a MUST) and is therefor not tested by this implementation.

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_3_IqIntegrationTest.java
@@ -87,13 +87,9 @@ public class RFC6121Section8_5_2_2_3_IqIntegrationTest extends AbstractSmackInte
     }
 
     @AfterClass
-    public void tearDown()
+    public void tearDown() throws InvocationTargetException, InstantiationException, IllegalAccessException
     {
-        try {
-            AccountUtilities.removeNonConnectedLocalUser(environment, entityWithoutResources.getLocalpart().asUnescapedString(), "secret");
-        } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        AccountUtilities.removeNonConnectedLocalUser(environment, entityWithoutResources.getLocalpart().asUnescapedString(), "secret");
     }
 
     @SmackIntegrationTest(section = "8.5.2.2.3", quote = "If the JID contained in the 'to' attribute is of the form <localpart@domainpart>, then the server MUST adhere to the following rules. [...] If there are no available resources or connected resources associated with the user, how the stanza is processed depends on the stanza type. [...] For an IQ stanza, the server itself MUST reply on behalf of the user with either an IQ result or an IQ error. Specifically, if the semantics of the qualifying namespace define a reply that the server can provide on behalf of the user [...] if not, then the server MUST reply with a <service-unavailable/> stanza error.")

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_1_IntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_1_IntegrationTest.java
@@ -223,7 +223,7 @@ public class RFC6121Section8_5_3_1_IntegrationTest extends AbstractSmackIntegrat
         doTestPresence(Presence.Type.unavailable);
     }
 
-    private void doTestMessage(final Message.Type type) throws SmackException.NotConnectedException, InterruptedException
+    private void doTestMessage(final Message.Type type) throws SmackException.NotConnectedException, InterruptedException, TimeoutException
     {
         // Setup test fixture.
         final String needle = StringUtils.randomString(9);
@@ -243,15 +243,13 @@ public class RFC6121Section8_5_3_1_IntegrationTest extends AbstractSmackIntegrat
 
             // Verify result.
             assertResult(stanzaReceived, "Expected '" + conTwo.getUser() + "' to receive the Message stanza of type '" + stanzaToSend.getType() + "' with stanza ID '" + stanzaToSend.getStanzaId() + "' that was sent to its full JID by '" + conOne.getUser() + "' (but the stanza was not received).");
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
         } finally {
             // Tear down test fixture.
             conTwo.removeStanzaListener(stanzaListener);
         }
     }
 
-    private void doTestPresence(final Presence.Type type) throws SmackException.NotConnectedException, InterruptedException
+    private void doTestPresence(final Presence.Type type) throws SmackException.NotConnectedException, InterruptedException, TimeoutException
     {
         // Setup test fixture.
         final String needle = StringUtils.randomString(9);
@@ -271,8 +269,6 @@ public class RFC6121Section8_5_3_1_IntegrationTest extends AbstractSmackIntegrat
 
             // Verify result.
             assertResult(stanzaReceived, "Expected '" + conTwo.getUser() + "' to receive the Presence stanza of type '" + stanzaToSend.getType() + "' with stanza ID '" + stanzaToSend.getStanzaId() + "' that was sent to its full JID by '" + conOne.getUser() + "' (but the stanza was not received).");
-        } catch (TimeoutException e) {
-            throw new RuntimeException(e);
         } finally {
             // Tear down test fixture.
             conTwo.removeStanzaListener(stanzaListener);

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0198/StreamManagementLowLevelIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0198/StreamManagementLowLevelIntegrationTest.java
@@ -242,7 +242,7 @@ public class StreamManagementLowLevelIntegrationTest extends AbstractSmackSpecif
      * Asserts that the server does not re-use the stream management ID for subsequent sessions.
      */
     @SmackIntegrationTest(section = "5", quote = "The SM-ID MUST NOT be reused for [...] subsequent sessions")
-    public void testStreamManagementIdUniqueInSubsequentSessions() throws XMPPException, SmackException, InterruptedException, IOException, NoSuchFieldException
+    public void testStreamManagementIdUniqueInSubsequentSessions() throws XMPPException, SmackException, InterruptedException, IOException, NoSuchFieldException, TestNotPossibleException, IllegalAccessException
     {
         // Setup test fixture.
         final int distinctConnectionCount = 5;
@@ -273,8 +273,6 @@ public class StreamManagementLowLevelIntegrationTest extends AbstractSmackSpecif
 
             // Verify result.
             assertEquals(distinctConnectionCount, uniqueIds.size(), "Expected the server to use distinct stream management IDs for subsequent sessions, but only " + uniqueIds.size() + " unique IDs were used between " + distinctConnectionCount + " connections.");
-        } catch (TestNotPossibleException | IllegalAccessException e) {
-            throw new RuntimeException(e);
         } finally {
             connections.forEach(this::recycle);
         }
@@ -284,7 +282,7 @@ public class StreamManagementLowLevelIntegrationTest extends AbstractSmackSpecif
      * Asserts that the server does not re-use the stream management ID for simultaneous sessions.
      */
     @SmackIntegrationTest(section = "5", quote = "The SM-ID MUST NOT be reused for simultaneous [...] sessions")
-    public void testStreamManagementIdUniqueInSimultaneousSessions() throws XMPPException, SmackException, InterruptedException, IOException, NoSuchFieldException
+    public void testStreamManagementIdUniqueInSimultaneousSessions() throws XMPPException, SmackException, InterruptedException, IOException, NoSuchFieldException, IllegalAccessException, TestNotPossibleException
     {
         // Setup test fixture.
         final int distinctConnectionCount = 5;
@@ -306,8 +304,6 @@ public class StreamManagementLowLevelIntegrationTest extends AbstractSmackSpecif
 
             // Verify result.
             assertEquals(distinctConnectionCount, uniqueIds.size(), "Expected the server to use distinct stream management IDs for simultaneous sessions, but only " + uniqueIds.size() + " unique IDs were used between " + distinctConnectionCount + " connections.");
-        } catch (TestNotPossibleException | IllegalAccessException e) {
-            throw new RuntimeException(e);
         } finally {
             connections.forEach(this::recycle);
         }


### PR DESCRIPTION
Some tests (and teardown methods) catch exceptions thrown, wrap that in a RuntimeException, and rethrow that.

This is likely the result of some kind of default IDE-based code template.

Rethrowing as a RuntimeException is undesirable. It doesn't notably change the semantic of the failure. It can cause the execution of all following tests to be aborted (as SmackIntegrationTestFramework isn't expecting instances of RuntimeException).

This commit throws the exception that was previously wrapped.

fixes #99 