### PR TITLE
Don't expect all Messages to have a body

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_1_MessageIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_1_MessageIntegrationTest.java
@@ -615,7 +615,7 @@ public class RFC6121Section8_5_2_1_1_MessageIntegrationTest extends AbstractSmac
 
             // Setup test fixture: prepare for the message stanza that is sent to the bare JID to be sent, and collected while being received by the various resources.
             final String needle = StringUtils.randomString(9);
-            final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && ((Message) s).getBody().equals(needle)));
+            final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && needle.equals(((Message) s).getBody())));
             final Map<EntityFullJid, Stanza> receivedBy = new ConcurrentHashMap<>(); // This is what will be evaluated by this test's assertions.
 
             // Setup test fixture: detect the message stanza that's sent to signal that the test stanza has been sent and processed
@@ -632,7 +632,7 @@ public class RFC6121Section8_5_2_1_1_MessageIntegrationTest extends AbstractSmac
                 }
             };
             final String stopNeedleRecipients = "STOP LISTENING, STANZAS HAVE BEEN PROCESSED " + StringUtils.randomString(7);
-            final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleRecipients)));
+            final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && stopNeedleRecipients.equals(((Message) s).getBody())));
 
             for (int i = 0; i < resourcePriorities.size(); i++) {
                 final XMPPConnection resourceConnection = i == 0 ? conTwo : additionalConnections.get(i - 1);
@@ -644,13 +644,13 @@ public class RFC6121Section8_5_2_1_1_MessageIntegrationTest extends AbstractSmac
 
             // Setup test fixture: detect the message stanza that's sent to signal the sender need not wait any longer for any potential stanza delivery errors.
             final String stopNeedleSender = "STOP LISTENING, ALL RECIPIENTS ARE DONE " + StringUtils.randomString(7);
-            final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conTwo.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleSender)));
+            final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conTwo.getUser()), (s -> s instanceof Message && stopNeedleSender.equals(((Message) s).getBody())));
             final SimpleResultSyncPoint stopListenerSenderSyncPoint = new SimpleResultSyncPoint();
             stopListenerSender = (e) -> stopListenerSenderSyncPoint.signal();
             conOne.addStanzaListener(stopListenerSender, stopDetectorSender);
 
             // Setup test fixture: detect an error that is sent back to the sender.
-            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && ((Message) s).getBody().equals(needle)));
+            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && needle.equals(((Message) s).getBody())));
             final Stanza[] errorReceived = { null };
             errorListener = (stanza) -> errorReceived[0] = stanza;
             conOne.addStanzaListener(errorListener, errorDetector);

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_3_IqIntegrationTest.java
@@ -506,7 +506,7 @@ public class RFC6121Section8_5_2_1_3_IqIntegrationTest extends AbstractSmackInte
                 }
             };
             final String stopNeedleRecipients = "STOP LISTENING, STANZAS HAVE BEEN PROCESSED " + StringUtils.randomString(7);
-            final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleRecipients)));
+            final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && stopNeedleRecipients.equals(((Message) s).getBody())));
 
             for (int i = 0; i < resourcePriorities.size(); i++) {
                 final XMPPConnection resourceConnection = i == 0 ? conTwo : additionalConnections.get(i - 1);

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_1_MessageIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_1_MessageIntegrationTest.java
@@ -84,7 +84,7 @@ public class RFC6121Section8_5_2_2_1_MessageIntegrationTest extends AbstractSmac
         try {
             final String needle = StringUtils.randomString(9);
 
-            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && ((Message) s).getBody().equals(needle)));
+            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && needle.equals(((Message) s).getBody())));
             final SimpleResultSyncPoint errorReceivedBySender = new SimpleResultSyncPoint();
             errorListener = (stanza) -> errorReceivedBySender.signal();
             conOne.addStanzaListener(errorListener, errorDetector);
@@ -126,7 +126,7 @@ public class RFC6121Section8_5_2_2_1_MessageIntegrationTest extends AbstractSmac
             final String needle = StringUtils.randomString(9);
 
             // Setup test fixture: detect an error that is sent back to the sender.
-            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && ((Message) s).getBody().equals(needle)));
+            final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && needle.equals(((Message) s).getBody())));
             final Stanza[] errorReceivedBySender = {null};
             errorListener = (stanza) -> errorReceivedBySender[0] = stanza;
             conOne.addStanzaListener(errorListener, errorDetector);

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_1_MessageIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_1_MessageIntegrationTest.java
@@ -352,7 +352,7 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
 
                 // Setup test fixture: prepare for the message stanza that is sent to the full JID (that has no online resource) to be sent, and collected while being received by the various resources.
                 final String needle = StringUtils.randomString(9);
-                final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && ((Message) s).getBody().equals(needle)));
+                final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && needle.equals(((Message) s).getBody())));
                 final Map<EntityFullJid, Stanza> receivedBy = new ConcurrentHashMap<>(); // This is what will be evaluated by this test's assertions.
 
                 // Setup test fixture: detect the message stanza that's sent to signal that the test stanza has been sent and processed
@@ -370,7 +370,7 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
                 };
 
                 final String stopNeedleRecipients = "STOP LISTENING, STANZAS HAVE BEEN PROCESSED " + StringUtils.randomString(7);
-                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleRecipients)));
+                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && stopNeedleRecipients.equals(((Message) s).getBody())));
 
                 for (int i = 0; i < resourcePriorities.size(); i++) {
                     final XMPPConnection resourceConnection = i == 0 ? conTwo : additionalConnections.get(i - 1);
@@ -499,7 +499,7 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
         try {
             // Setup test fixture: prepare for the message stanza that is sent to the full JID (that has no online resource) to be sent.
             final String needle = StringUtils.randomString(9);
-            final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && ((Message) s).getBody().equals(needle)));
+            final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && needle.equals(((Message) s).getBody())));
             final SimpleResultSyncPoint stanzaReceived = new SimpleResultSyncPoint();
 
             // Setup test fixture: create connections for the additional resources (based on the user used for 'conTwo').
@@ -750,7 +750,7 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
 
                 // Setup test fixture: prepare for the message stanza that is sent to the bare JID to be sent, and collected while being received by the various resources.
                 final String needle = StringUtils.randomString(9);
-                final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && ((Message) s).getBody().equals(needle)));
+                final StanzaFilter needleDetector = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getType() == messageType && needle.equals(((Message) s).getBody())));
                 final Map<EntityFullJid, Stanza> receivedBy = new ConcurrentHashMap<>(); // This is what will be evaluated by this test's assertions.
 
                 // Setup test fixture: detect the message stanza that's sent to signal that the test stanza has been sent and processed
@@ -769,7 +769,7 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
                     }
                 };
                 final String stopNeedleRecipients = "STOP LISTENING, STANZAS HAVE BEEN PROCESSED " + StringUtils.randomString(7);
-                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleRecipients)));
+                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && stopNeedleRecipients.equals(((Message) s).getBody())));
 
                 for (int i = 0; i < resourcePriorities.size(); i++) {
                     final XMPPConnection resourceConnection = i == 0 ? conTwo : additionalConnections.get(i - 1);
@@ -781,13 +781,13 @@ public class RFC6121Section8_5_3_2_1_MessageIntegrationTest extends AbstractSmac
 
                 // Setup test fixture: detect the message stanza that's sent to signal the sender need not wait any longer for any potential stanza delivery errors.
                 final String stopNeedleSender = "STOP LISTENING, ALL RECIPIENTS ARE DONE " + StringUtils.randomString(7);
-                final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conThree.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleSender)));
+                final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conThree.getUser()), (s -> s instanceof Message && stopNeedleSender.equals(((Message) s).getBody())));
                 final SimpleResultSyncPoint stopListenerSenderSyncPoint = new SimpleResultSyncPoint();
                 stopListenerSender = (e) -> stopListenerSenderSyncPoint.signal();
                 conOne.addStanzaListener(stopListenerSender, stopDetectorSender);
 
                 // Setup test fixture: detect an error that is sent back to the sender.
-                final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && ((Message) s).getBody().equals(needle)));
+                final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && needle.equals(((Message) s).getBody())));
                 final Stanza[] errorReceived = {null};
                 errorListener = (stanza) -> errorReceived[0] = stanza;
                 conOne.addStanzaListener(errorListener, errorDetector);

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_2_PresenceIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_2_PresenceIntegrationTest.java
@@ -544,7 +544,7 @@ public class RFC6121Section8_5_3_2_2_PresenceIntegrationTest extends AbstractSma
                     }
                 };
                 final String stopNeedleRecipients = "STOP LISTENING, STANZAS HAVE BEEN PROCESSED " + StringUtils.randomString(7);
-                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleRecipients)));
+                final StanzaFilter stopDetectorRecipients = new AndFilter(FromMatchesFilter.createFull(conOne.getUser()), (s -> s instanceof Message && stopNeedleRecipients.equals(((Message) s).getBody())));
 
                 for (int i = 0; i < resourcePriorities.size(); i++) {
                     final XMPPConnection resourceConnection = i == 0 ? conTwo : additionalConnections.get(i - 1);
@@ -556,13 +556,13 @@ public class RFC6121Section8_5_3_2_2_PresenceIntegrationTest extends AbstractSma
 
                 // Setup test fixture: detect the message stanza that's sent to signal the sender need not wait any longer for any potential stanza delivery errors.
                 final String stopNeedleSender = "STOP LISTENING, ALL RECIPIENTS ARE DONE " + StringUtils.randomString(7);
-                final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conThree.getUser()), (s -> s instanceof Message && ((Message) s).getBody().equals(stopNeedleSender)));
+                final StanzaFilter stopDetectorSender = new AndFilter(FromMatchesFilter.createBare(conThree.getUser()), (s -> s instanceof Message && stopNeedleSender.equals(((Message) s).getBody())));
                 final SimpleResultSyncPoint stopListenerSenderSyncPoint = new SimpleResultSyncPoint();
                 stopListenerSender = (e) -> stopListenerSenderSyncPoint.signal();
                 conOne.addStanzaListener(stopListenerSender, stopDetectorSender);
 
                 // Setup test fixture: detect an error that is sent back to the sender.
-                final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && ((Message) s).getBody().equals(needle)));
+                final StanzaFilter errorDetector = new AndFilter((s -> s instanceof Message && ((Message) s).getType() == Message.Type.error && needle.equals(((Message) s).getBody())));
                 final Stanza[] errorReceived = {null};
                 errorListener = (stanza) -> errorReceived[0] = stanza;
                 conOne.addStanzaListener(errorListener, errorDetector);

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0133/AdHocCommandIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0133/AdHocCommandIntegrationTest.java
@@ -1131,7 +1131,7 @@ public class AdHocCommandIntegrationTest extends AbstractAdHocCommandIntegration
 
         StanzaListener stanzaListener = stanza -> {
             Message message = (Message) stanza;
-            if (message.getBody().contains(announcement)) {
+            if (message.getBody() != null && message.getBody().contains(announcement)) {
                 syncPoint.signal();
             }
         };
@@ -1169,7 +1169,7 @@ public class AdHocCommandIntegrationTest extends AbstractAdHocCommandIntegration
 
         StanzaListener stanzaListener = stanza -> {
             Message message = (Message) stanza;
-            if (newMOTD.stream().allMatch(s -> message.getBody().contains(s))) {
+            if (newMOTD.stream().allMatch(s -> message.getBody() != null && message.getBody().contains(s))) {
                 syncPoint.signal();
             }
         };
@@ -1227,7 +1227,7 @@ public class AdHocCommandIntegrationTest extends AbstractAdHocCommandIntegration
 
         StanzaListener stanzaListener = stanza -> {
             Message message = (Message) stanza;
-            if (newMOTD.stream().allMatch(s -> message.getBody().contains(s))) {
+            if (newMOTD.stream().allMatch(s -> message.getBody() != null && message.getBody().contains(s))) {
                 syncPoint.signal();
             }
         };
@@ -1329,7 +1329,7 @@ public class AdHocCommandIntegrationTest extends AbstractAdHocCommandIntegration
         StanzaListener stanzaListener = stanza -> {
             if (stanza instanceof Message) {
                 Message message = (Message) stanza;
-                if (newWelcomeMessage.stream().allMatch(s -> message.getBody().contains(s))) {
+                if (newWelcomeMessage.stream().allMatch(s -> message.getBody() != null && message.getBody().contains(s))) {
                     syncPoint.signal();
                 }
             }


### PR DESCRIPTION
This prevents NullPointerExceptions when unexpected messages are being processed.

fixes #98