### PR TITLE
Clean up JIDs used for MUC rooms

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/muc/MUCAvatarIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MUCAvatarIntegrationTest.java
@@ -50,7 +50,7 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
     {
         super(environment);
 
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mucavatar-support");
+        final EntityBareJid mucAddress = getRandomRoom("mucavatar-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -69,7 +69,7 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
     public void testPublishAvatar() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mucavatar-publish");
+        final EntityBareJid mucAddress = getRandomRoom("mucavatar-publish");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -122,7 +122,7 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
     public void testUnpublishAvatar() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mucavatar-unpublish");
+        final EntityBareJid mucAddress = getRandomRoom("mucavatar-unpublish");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -156,7 +156,7 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
     public void testRetrieveAvatar() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mucavatar-unpublish");
+        final EntityBareJid mucAddress = getRandomRoom("mucavatar-unpublish");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -186,7 +186,7 @@ public class MUCAvatarIntegrationTest extends AbstractMultiUserChatIntegrationTe
     public void testPNGSupport() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mucavatar-pngsupport");
+        final EntityBareJid mucAddress = getRandomRoom("mucavatar-png");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -61,7 +61,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanNonOccupantWithoutOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-nonoccupant-without-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-nonoccupant-without-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
@@ -96,7 +96,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanOccupantWithoutOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-occupant-without-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-occupant-without-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -148,7 +148,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanNonOccupantWithOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-nonoccupant-with-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-nonoccupant-with-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
@@ -183,7 +183,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanOccupantWithOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-occupant-with-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-occupant-with-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -234,7 +234,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testParticipantNotAllowedToBan() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
@@ -264,7 +264,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanNonOccupantJidOnBanList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-nonoccupant-banned-jid-on-banlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-nonoccupant-banned-jid-on-banlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
@@ -295,7 +295,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanOccupantJidOnBanList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-occupant-banned-jid-on-banlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-occupant-banned-jid-on-banlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -343,7 +343,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBanOccupantRemovesRegisteredNickname() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-removes-registered-nickname");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-removes-registered-nickname");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -413,7 +413,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void testBannedOccupantReceivesRemoval() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-notification");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-notification");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -469,7 +469,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void mucTestRemainingOccupantsInformedOfBan() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-ban-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-ban-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -537,7 +537,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void mucTestAdminCannotBanSelf() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-cannot-ban-self");
+        final EntityBareJid mucAddress = getRandomRoom("admin-cannot-ban-self");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = conTwo.getUser().asEntityBareJid();
@@ -568,7 +568,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void mucTestAdminCannotBanOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-cannot-ban-owner");
+        final EntityBareJid mucAddress = getRandomRoom("admin-cannot-ban-owner");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = conOne.getUser().asEntityBareJid();
@@ -599,7 +599,7 @@ public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatI
     public void mucTestOwnerCannotBanSelf() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-cannot-ban-self");
+        final EntityBareJid mucAddress = getRandomRoom("owner-cannot-ban-self");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = conOne.getUser().asEntityBareJid();
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -64,7 +64,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminRequestsBanList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-banlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-requests-banlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -104,7 +104,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListFullJid() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-fulljid");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-fulljid");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityFullJid targetAddress = JidCreate.entityFullFrom("test@example.org/foobar");
@@ -155,7 +155,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListItemCheck() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-attr");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-attr");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("test@example.org");
@@ -199,7 +199,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListMultipleItems() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -242,7 +242,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void testParticipantNotAllowedToModifyBanList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("banned-user-" + randomString + "@example.org");
@@ -273,7 +273,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListMultipleItemsUnban() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -318,7 +318,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListMultipleItemsWithOptionalAttributes() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-multiple-opt");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-multiple-opt");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -362,7 +362,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestAdminBanListIsDelta() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-delta");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-delta");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -410,7 +410,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestBanListOccupantsInformedOfBan() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-notification");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-notification");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -467,7 +467,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestBanListRemainingOccupantsInformedOfBan() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -537,7 +537,7 @@ public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserC
     public void mucTestBanListRemovesRegisteredNickname() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-banlist-removes-registered-nickname");
+        final EntityBareJid mucAddress = getRandomRoom("admin-banlist-removes-registered-nickname");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -56,7 +56,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void testGrantMembership() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-grant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("target-user-" + randomString + "@example.org");
@@ -95,7 +95,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void testGrantMembershipWithNick() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-nick");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-grant-nick");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -135,7 +135,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void testGrantMembershipWithReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-grant-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -174,7 +174,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void testParticipantNotAllowedToGrantMembership() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-grant-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-grant-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -210,7 +210,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void testMemberOnMemberList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-on-memberlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-on-memberlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -250,7 +250,7 @@ public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiU
     public void mucTestOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -56,7 +56,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     public void testGrantModerator() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-grant");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-grant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -109,7 +109,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     public void testGrantModeratorOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-grant-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-grant-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -163,7 +163,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     public void testParticipantNotAllowedToGrantModeratorStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -214,7 +214,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     public void testModeratorOnModeratorList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-on-moderatorlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-on-moderatorlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -268,7 +268,7 @@ public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMul
     @SmackIntegrationTest(section = "9.6", quote = "The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator status by including an <x/> element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an <item/> child with the 'role' attribute set to a value of \"moderator\".")
     public void mucTestOccupantsInformed() throws Exception {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -64,7 +64,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestAdminRequestsMemberList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-memberlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-requests-memberlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -99,7 +99,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestAdminMemberListItemCheck() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-attr");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-attr");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("test@example.org");
@@ -137,7 +137,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestAdminMemberListMultipleItems() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -180,7 +180,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestAdminMemberListMultipleItemsRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -226,7 +226,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestAdminMemberListIsDelta() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-delta");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-delta");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress1 = JidCreate.entityBareFrom("test1@example.org");
@@ -274,7 +274,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestMemberListNoEntryAfterRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-noentry");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-noentry");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -308,7 +308,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestMemberListRemainingOccupantsInformedOfRevokeOpenRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-revoke-open");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-broadcast-revoke-open");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -379,7 +379,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestMemberListRemainingOccupantsInformedOfRevokeMemberOnlyRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-revoke-memberonly");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-broadcast-revoke-memberonly");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -439,7 +439,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestMemberListNoChangeWithInviteInOpenRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-invite-open");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-invite-open");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -470,7 +470,7 @@ public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUs
     public void mucTestMemberListOccupantsInformedOfGrantOpenRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberlist-broadcast-grant-open");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberlist-broadcast-grant-open");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -58,7 +58,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminRequestsModeratorList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-requests-moderatorlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-requests-moderatorlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -93,7 +93,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminModeratorListItemCheck() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-not-on-moderator-list");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-not-on-moderator-list");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -158,7 +158,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminModeratorListMultipleItems() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
@@ -237,7 +237,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminModeratorListMultipleItemsRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
@@ -323,7 +323,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminModeratorListIsDelta() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-delta");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-delta");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);
@@ -402,7 +402,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void mucTestAdminModeratorListBroadcast() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -512,7 +512,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void testAdminNotAllowedToRevokeModeratorFromAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-admin-rejected");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-revoke-admin-rejected");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTargetAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerThree.getMultiUserChat(mucAddress);
@@ -584,7 +584,7 @@ public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMult
     public void testAdminNotAllowedToRevokeModeratorFromOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderatorlist-revoke-owner-rejected");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderatorlist-revoke-owner-rejected");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
@@ -64,7 +64,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void testRevokeMembership() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -105,7 +105,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void testRevokeMembershipWithReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-revoke-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -145,7 +145,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void testParticipantNotAllowedToRevokeMembership() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-revoke-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-revoke-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -181,7 +181,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void testMemberNotOnMemberList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-member-not-on-memberlist");
+        final EntityBareJid mucAddress = getRandomRoom("admin-member-not-on-memberlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final EntityBareJid targetAddress = JidCreate.entityBareFrom("member-user-" + randomString + "@example.org");
@@ -217,7 +217,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void mucTestOccupantsInformedRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-memberrevoke-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-memberrevoke-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -305,7 +305,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void mucTestRemovalOfUserInMembersOnlyRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-revoke-removal");
+        final EntityBareJid mucAddress = getRandomRoom("admin-revoke-removal");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -363,7 +363,7 @@ public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMulti
     public void mucTestOccupantsInformedKick() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-revoke-removal-notif");
+        final EntityBareJid mucAddress = getRandomRoom("admin-revoke-removal-notif");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -58,7 +58,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testRevokeModerator() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -118,7 +118,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testRevokeModeratorWithReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-reason");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -178,7 +178,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testParticipantNotAllowedToRevokeModerator() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -234,7 +234,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testModeratorNotOnModeratorList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-not-on-moderator-list");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-not-on-moderator-list");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -290,7 +290,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void mucTestOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -376,7 +376,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testAdminNotAllowedToRevokeModeratorFromAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-admin-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke-admin-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -433,7 +433,7 @@ public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMu
     public void testAdminNotAllowedToRevokeModeratorFromOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-admin-moderator-revoke-owner-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("admin-moderator-revoke-owner-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
@@ -58,7 +58,7 @@ public class MultiUserChatInvitationIntegrationTest extends AbstractMultiUserCha
         "The <room@service> itself MUST [...] send the invitation to the invitee specified in the 'to' address;")
     public void mucTestMediatedInviteGetDelivered() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mediated-invite-delivery");
+        final EntityBareJid mucAddress = getRandomRoom("mediated-invite-delivery");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOne = Resourcepart.from("one-" + randomString);
@@ -90,7 +90,7 @@ public class MultiUserChatInvitationIntegrationTest extends AbstractMultiUserCha
         "full JID, or occupant JID of the inviter [...]")
     public void mucTestMediatedInviteFrom() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-mediated-invite-from");
+        final EntityBareJid mucAddress = getRandomRoom("mediated-invite-from");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOne = Resourcepart.from("one-" + randomString);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
@@ -56,7 +56,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "kicked occupant, including status code 307 in the extended presence information")
     public void mucTestOccupantInformedOfKick() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-occupant-informed-of-kick");
+        final EntityBareJid mucAddress = getRandomRoom("occupant-informed-of-kick");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -101,7 +101,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "After removing the kicked occupant(s), the service MUST then inform the moderator of success")
     public void mucTestModeratorInformedOfKickSuccess() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-informed-of-kick-success");
+        final EntityBareJid mucAddress = getRandomRoom("moderator-informed-of-kick-success");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -147,7 +147,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "(<room@service/nick>) to all the remaining occupants [...] including the status code [...]")
     public void mucTestRemainingOccupantsInformedOfKick() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-remaining-occupants-informed-of-kick-success");
+        final EntityBareJid mucAddress = getRandomRoom("remaining-occupants-informed-of-kick-success");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
@@ -214,7 +214,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "attempts to kick an admin, [...] the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void mucTestModeratorMemberCannotKickAdmin() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-member-cannot-kick-admin");
+        final EntityBareJid mucAddress = getRandomRoom("moderator-member-cannot-kick-admin");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);
@@ -291,7 +291,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "member [...] attempts to kick an owner [...], the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void mucTestModeratorMemberCannotKickOwner() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-member-cannot-kick-owner");
+        final EntityBareJid mucAddress = getRandomRoom("moderator-member-cannot-kick-owner");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -347,7 +347,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "[...] admin attempts to kick an owner [...], the service MUST deny the request and return a <not-allowed/> error to the sender")
     public void mucTestModeratorAdminCannotKickOwner() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-admin-cannot-kick-admin");
+        final EntityBareJid mucAddress = getRandomRoom("moderator-admin-cannot-kick-admin");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -404,7 +404,7 @@ public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUser
         "a <forbidden/> error.")
     public void mucTestParticipantNotAllowedToKick() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-participant-kick");
+        final EntityBareJid mucAddress = getRandomRoom("participant-kick");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByThree = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
@@ -59,7 +59,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
         "moderators are stipulated to have privileges to [...] modify the subject")
     public void mucTestModeratorAllowedToChangeSubject() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-moderator-change-subject");
+        final EntityBareJid mucAddress = getRandomRoom("moderator-change-subject");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -98,7 +98,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
         "message of type \"error\" specifying a <forbidden/> error condition")
     public void mucTestParticipantNotAllowedToChangeSubject() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-participant-change-subject");
+        final EntityBareJid mucAddress = getRandomRoom("participant-change-subject");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -131,7 +131,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
         "The MUC service MUST reflect the [subject change] to all other occupants with a 'from' address equal to the room JID or to the occupant JID that corresponds to the sender of the subject change")
     public void mucTestChangeSubjectIsReflected() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-change-subject-reflection");
+        final EntityBareJid mucAddress = getRandomRoom("change-subject-reflection");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -182,7 +182,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
         "In order to remove the existing subject but not provide a new subject (i.e., set the subject to be empty), the client shall send an empty <subject/> element")
     public void mucTestModeratorAllowedToRemoveSubject() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-remove-subject");
+        final EntityBareJid mucAddress = getRandomRoom("remove-subject");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -234,7 +234,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
             "message of type \"error\" specifying a <forbidden/> error condition")
     public void mucTestParticipantNotAllowedToRemoveSubject() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-participant-change-subject");
+        final EntityBareJid mucAddress = getRandomRoom("participant-change-subject");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -268,7 +268,7 @@ public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMul
         "The MUC service MUST reflect the [subject removal] to all other occupants with a 'from' address equal to the room JID or to the occupant JID that corresponds to the sender of the subject change")
     public void mucTestRemoveSubjectIsReflected() throws Exception
     {
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-remove-subject-reflection");
+        final EntityBareJid mucAddress = getRandomRoom("remove-subject-reflection");
         final MultiUserChat mucAsSeenByOne = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTwo = mucManagerTwo.getMultiUserChat(mucAddress);
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
@@ -83,7 +83,7 @@ public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserCha
     public void testSendPM() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-occupant-pm");
+        final EntityBareJid mucAddress = getRandomRoom("occupant-pm");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -141,7 +141,7 @@ public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserCha
     public void testSendGroupchatPM() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-occupant-pm-groupchat");
+        final EntityBareJid mucAddress = getRandomRoom("occupant-pm-groupchat");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -199,7 +199,7 @@ public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserCha
     public void testSendNonOccupantTargetPM() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-occupant-pm-nonoccupant-target");
+        final EntityBareJid mucAddress = getRandomRoom("occupant-pm-nonoccupant-target");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -243,7 +243,7 @@ public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserCha
     public void testSendNonOccupantSenderPM() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-occupant-pm-nonoccupant-sender");
+        final EntityBareJid mucAddress = getRandomRoom("occupant-pm-nonoccupant-sender");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
@@ -54,7 +54,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
         // which suggests that this is optional functionality. The specification does not explicitly say how to test for
         // support. This implementation will use any XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -78,7 +78,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testOwnerRequestsAdminList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-requests-adminlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-requests-adminlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -110,7 +110,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testUserRequestsAdminList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-adminlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-user-requests-adminlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -142,7 +142,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testParticipantRequestsAdminList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-adminlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-user-requests-adminlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -176,7 +176,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListItemCheck() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-list-itemcheck");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-list-itemcheck");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -212,7 +212,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListMultipleItems() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -247,7 +247,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminAdminListMultipleItemsRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -290,7 +290,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testOwnerAdminListIsDelta() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-delta");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-delta");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityBareJid unchangedAddress = JidCreate.entityBareFrom("unchanged-admin-" + randomString + "@example.org");
@@ -338,7 +338,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListRejectAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-admin");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-reject-admin");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -375,7 +375,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListRejectMember() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-reject-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -412,7 +412,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListRejectOutcast() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-reject-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -446,7 +446,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminListRejectNoneAffiliation() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-reject-nonaff");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-reject-nonaff");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -478,7 +478,7 @@ public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUse
     public void testAdminAdminListBroadcast() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-adminlist-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-adminlist-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -61,7 +61,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     {
         super(environment);
 
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-setup");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-setup");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -81,7 +81,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testObtainRoomConfigWithoutRoleOrAffiliation() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-no-role-or-affiliation");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-get-no-role-or-affiliation");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -109,7 +109,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testObtainRoomConfigNonAffiliatedUser() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-participant");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-get-by-participant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final Resourcepart nicknameParticipant = Resourcepart.from("participant-" + randomString);
@@ -143,7 +143,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testObtainRoomConfigOwnerNonJoined() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-owner-not-joined");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-get-by-owner-not-joined");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -184,7 +184,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testObtainRoomConfigOwnerJoined() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-get-by-owner-joined");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-get-by-owner-joined");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -219,7 +219,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testObtainRoomConfigHasCurrentOptionsAsDefaults() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-defaults");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-defaults");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -288,7 +288,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigCancel() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-cancel");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-cancel");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -325,7 +325,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigDropAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-admin");
+        final EntityBareJid mucAddress = getRandomRoom("owner-drop-admin");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
@@ -418,7 +418,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigAddAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-admin");
+        final EntityBareJid mucAddress = getRandomRoom("owner-add-admin");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
@@ -509,7 +509,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigDropOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-drop-owner");
+        final EntityBareJid mucAddress = getRandomRoom("owner-drop-owner");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
@@ -602,7 +602,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigRemoveLastOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-remove-last");
+        final EntityBareJid mucAddress = getRandomRoom("owner-remove-last");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -629,7 +629,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigAddOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-add-owner");
+        final EntityBareJid mucAddress = getRandomRoom("owner-add-owner");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerThree.getMultiUserChat(mucAddress);
@@ -720,7 +720,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigToMemberOnly() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-make-memberonly");
+        final EntityBareJid mucAddress = getRandomRoom("owner-make-memberonly");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByMember = mucManagerThree.getMultiUserChat(mucAddress);
@@ -809,7 +809,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigNotification170() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-170");
+        final EntityBareJid mucAddress = getRandomRoom("owner-notify-170");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -864,7 +864,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigNotification171() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-171");
+        final EntityBareJid mucAddress = getRandomRoom("owner-notify-171");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -919,7 +919,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigNotification172() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-172");
+        final EntityBareJid mucAddress = getRandomRoom("owner-notify-172");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -971,7 +971,7 @@ public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigNotification173() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-notify-173");
+        final EntityBareJid mucAddress = getRandomRoom("owner-notify-173");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
@@ -68,7 +68,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomLockedWhenCreated() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-locked-when-created");
+        final EntityBareJid mucAddress = getRandomRoom("owner-locked-when-created");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -104,7 +104,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomResponseIndicatesAcknowledgement() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-response-indicates-acknowledgement");
+        final EntityBareJid mucAddress = getRandomRoom("owner-response-indicates-acknowledgement");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
@@ -137,7 +137,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomResponseIndicatesCreatorIsOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-response-indicates-creator-is-owner");
+        final EntityBareJid mucAddress = getRandomRoom("owner-response-indicates-creator-is-owner");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
@@ -172,7 +172,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigurationFormRequest() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-conf-form");
+        final EntityBareJid mucAddress = getRandomRoom("owner-request-conf-form");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
@@ -209,7 +209,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigurationFormResponse() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-conf-form-response");
+        final EntityBareJid mucAddress = getRandomRoom("owner-request-conf-form-response");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
@@ -258,7 +258,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigurationUnlocksRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-config-unlocks");
+        final EntityBareJid mucAddress = getRandomRoom("owner-config-unlocks");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -352,7 +352,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomRequestInstantRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-request-instant");
+        final EntityBareJid mucAddress = getRandomRoom("owner-request-instant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -400,7 +400,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomConfigCancelDestroysRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-cancel-destroys");
+        final EntityBareJid mucAddress = getRandomRoom("owner-cancel-destroys");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         final EntityFullJid ownerMucAddress = JidCreate.entityFullFrom(mucAddress, nicknameOwner);
@@ -454,7 +454,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomRequestInstantUnlocksRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-instant-unlocks");
+        final EntityBareJid mucAddress = getRandomRoom("owner-instant-unlocks");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -513,7 +513,7 @@ public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUs
     public void testRoomRequestInitialConfigForm() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-get-config");
+        final EntityBareJid mucAddress = getRandomRoom("owner-get-config");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -60,7 +60,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testDestroyPersistentRoom() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-prst");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-prst");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -106,7 +106,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testDestroyTemporaryRoom() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-temporary");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-temporary");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -151,7 +151,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAlternateVenue() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenue");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-alternatevenue");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -184,7 +184,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAlternateVenuePassword() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-alternatevenuepassword");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-alternatevenuepassword");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -217,7 +217,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testReason() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-reason");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -250,7 +250,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testPresence() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TimeoutException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presence");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-presence");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -306,7 +306,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testPresenceOptional() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TimeoutException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-presenceext");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-presenceext");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -371,7 +371,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAuthorizationAdmin() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-admin");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-auth-admin");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -413,7 +413,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAuthorizationMember() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException, MultiUserChatException.MucConfigurationNotSupportedException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-auth-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -455,7 +455,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAuthorizationOutcast() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-outcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-auth-outcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -493,7 +493,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAuthorizationParticipant() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-participant");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-auth-participant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -529,7 +529,7 @@ public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiU
     public void testAuthorizationNonParticipant() throws MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, XmppStringprepException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-destroy-auth-nonparticipant");
+        final EntityBareJid mucAddress = getRandomRoom("owner-destroy-auth-nonparticipant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
@@ -52,7 +52,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
         // which suggests that this is optional functionality. The specification does not explicitly say how to test for
         // support. This implementation will use any XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -71,7 +71,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminMember() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         
@@ -108,7 +108,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminUnaffiliated() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-unaffiliated");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-unaffiliated");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -139,7 +139,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminMemberWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-member-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-member-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -193,7 +193,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminUnaffiliatedWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-unaffiliated-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-unaffiliated-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -241,7 +241,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-reason");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -272,7 +272,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testGrantAdminOptionalReasonWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-reason-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-reason-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -320,7 +320,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testUserNotAllowedToGrantAdminStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-user-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -351,7 +351,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testUserNotAllowedToGrantAdminStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-user-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-user-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
 
@@ -386,7 +386,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testParticipantNotAllowedToGrantAdminStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-participant-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -421,7 +421,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testParticipantNotAllowedToGrantAdminStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-grant-participant-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-grant-participant-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -472,7 +472,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testAdminOnAdminList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-on-adminlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-on-adminlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -501,7 +501,7 @@ public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUs
     public void testOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
@@ -52,7 +52,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
         // which suggests that this is optional functionality. The specification does not explicitly say how to test for
         // support. This implementation will use any XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -71,7 +71,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testGrantOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         
@@ -102,7 +102,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testGrantOwnerWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -150,7 +150,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testGrantOwnerOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-reason");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -181,7 +181,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testGrantOwnerOptionalReasonWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-reason-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-reason-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -229,7 +229,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testUserNotAllowedToGrantOwnerStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-user-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -260,7 +260,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testUserNotAllowedToGrantOwnerStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-user-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-user-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
 
@@ -295,7 +295,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testParticipantNotAllowedToGrantOwnerStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-participant-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -330,7 +330,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testParticipantNotAllowedToGrantOwnerStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-grant-participant-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-grant-participant-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -381,7 +381,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testOwnerOnOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-on-ownerlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-on-ownerlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -410,7 +410,7 @@ public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUs
     public void testOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
@@ -54,7 +54,7 @@ public class MultiUserChatOwnerIntegrationTest extends AbstractMultiUserChatInte
     public void testRoomHasOwnerAfterOriginalOwnerLeaves() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-after-leave");
+        final EntityBareJid mucAddress = getRandomRoom("owner-after-leave");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
@@ -55,7 +55,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
         // which suggests that this is optional functionality. The specification does not explicitly say how to test for
         // support. This implementation will use any XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-list-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-list-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -75,7 +75,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerRequestsOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-requests-ownerlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-requests-ownerlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -107,7 +107,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testUserRequestsOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-ownerlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-user-requests-ownerlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -139,7 +139,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testParticipantRequestsOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-user-requests-ownerlist");
+        final EntityBareJid mucAddress = getRandomRoom("owner-user-requests-ownerlist");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -173,7 +173,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListItemCheck() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-list-itemcheck");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-list-itemcheck");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -209,7 +209,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListMultipleItems() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-multiple");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-multiple");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -244,7 +244,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testAdminOwnerListMultipleItemsRevoke() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -287,7 +287,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerOwnerListIsDelta() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-delta");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-delta");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -330,7 +330,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListRejectAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-admin");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-reject-admin");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByAdmin = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -367,7 +367,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListRejectMember() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-reject-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByMember = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -404,7 +404,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListRejectOutcast() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-member");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-reject-member");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -438,7 +438,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListRejectNoneAffiliation() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-reject-nonaff");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-reject-nonaff");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -470,7 +470,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testOwnerListRejectRemovalLastOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-remove-last");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-remove-last");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -498,7 +498,7 @@ public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUse
     public void testAdminOwnerListBroadcast() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-ownerlist-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-ownerlist-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget1 = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget2 = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
@@ -52,7 +52,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
         // which suggests that this is optional functionality. The specification does not explicitly say how to test for
         // support. This implementation will use any XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -76,7 +76,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testRevokeAdmin() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -114,7 +114,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testRevokeAdminWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -170,7 +170,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testRevokeAdminOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-reason");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -208,7 +208,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testRevokeAdminOptionalReasonWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-reason-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-reason-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -263,7 +263,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testUserNotAllowedToRevokeAdminStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-user-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -301,7 +301,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testUserNotAllowedToRevokeAdminStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-user-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-user-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
 
@@ -343,7 +343,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testParticipantNotAllowedToRevokeAdminStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-participant-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -385,7 +385,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testParticipantNotAllowedToRevokeAdminStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-revoke-participant-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-revoke-participant-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -443,7 +443,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testOwnerNotOnOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-not-on-admin-list");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-not-on-admin-list");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -484,7 +484,7 @@ public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiU
     public void testOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-admin-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-admin-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
@@ -53,7 +53,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
         // return a <not-authorized/> error to the owner who made the request."
         // This implementation will use that XMPP error in response to a change request as an indication that
         // the feature is not supported by the server under test.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-support");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-support");
         final MultiUserChat muc = mucManagerOne.getMultiUserChat(mucAddress);
         createMuc(muc, Resourcepart.from("owner-" + randomString));
         try {
@@ -77,7 +77,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testRevokeOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -115,7 +115,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testRevokeOwnerWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -171,7 +171,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testRevokeOwnerOptionalReason() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-reason");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-reason");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -209,7 +209,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testRevokeOwnerOptionalReasonWhileInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-reason-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-reason-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -264,7 +264,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testUserNotAllowedToRevokeOwnerStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-user-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -302,7 +302,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testUserNotAllowedToRevokeOwnerStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-user-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-user-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
 
@@ -344,7 +344,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testParticipantNotAllowedToRevokeOwnerStatus() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-participant-notallowed");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
 
@@ -386,7 +386,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testParticipantNotAllowedToRevokeOwnerStatusInRoom() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-participant-notallowed-inroom");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-participant-notallowed-inroom");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);
@@ -444,7 +444,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testOwnerRemoveLastOwner() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-revoke-last");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-revoke-last");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
 
@@ -474,7 +474,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testOwnerNotOnOwnerList() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-not-on-owner-list");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-not-on-owner-list");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
 
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -515,7 +515,7 @@ public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiU
     public void testOccupantsInformed() throws Exception
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-owner-owner-broadcast");
+        final EntityBareJid mucAddress = getRandomRoom("owner-owner-broadcast");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByTarget = mucManagerThree.getMultiUserChat(mucAddress);

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
@@ -47,7 +47,7 @@ public class MultiUserChatSecurityConsiderationsIntegrationTest extends Abstract
     {
         super(environment);
 
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-security-setup");
+        final EntityBareJid mucAddress = getRandomRoom("security-setup");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
         try {
@@ -68,7 +68,7 @@ public class MultiUserChatSecurityConsiderationsIntegrationTest extends Abstract
     public void testPublicLoggingStatusOnInitialPresence() throws XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-security-initial-170");
+        final EntityBareJid mucAddress = getRandomRoom("security-initial-170");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -100,7 +100,7 @@ public class MultiUserChatSecurityConsiderationsIntegrationTest extends Abstract
     public void testPublicLoggingStatusOnConfigChange() throws XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, TestNotPossibleException, TimeoutException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-security-reconfig-170");
+        final EntityBareJid mucAddress = getRandomRoom("security-reconfig-170");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -145,7 +145,7 @@ public class MultiUserChatSecurityConsiderationsIntegrationTest extends Abstract
     public void testAnonymityStatusOnInitialPresence() throws XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, TestNotPossibleException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-security-initial-100");
+        final EntityBareJid mucAddress = getRandomRoom("security-initial-100");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);
@@ -173,7 +173,7 @@ public class MultiUserChatSecurityConsiderationsIntegrationTest extends Abstract
     public void testAnonymityStatusOnConfigChange() throws XmppStringprepException, MultiUserChatException.MucAlreadyJoinedException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, MultiUserChatException.MissingMucCreationAcknowledgeException, SmackException.NoResponseException, InterruptedException, MultiUserChatException.NotAMucServiceException, TestNotPossibleException, TimeoutException
     {
         // Setup test fixture.
-        final EntityBareJid mucAddress = getRandomRoom("smack-inttest-security-reconfig-172");
+        final EntityBareJid mucAddress = getRandomRoom("security-reconfig-172");
         final MultiUserChat mucAsSeenByOwner = mucManagerOne.getMultiUserChat(mucAddress);
         final MultiUserChat mucAsSeenByParticipant = mucManagerTwo.getMultiUserChat(mucAddress);
         final Resourcepart nicknameOwner = Resourcepart.from("owner-" + randomString);


### PR DESCRIPTION
The room generation method adds a prefix, that was duplicated in most invocations. This leads to JIDs that are needlessly long.

This commit doesn't introduce functional changes, but makes things slightly easier to read.

fixes #106