### PR TITLE
Fix #110: Inconsistent results for RosterIntegrationTest

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_3_IqIntegrationTest.java
@@ -490,7 +490,7 @@ public class RFC6121Section8_5_3_2_3_IqIntegrationTest extends AbstractSmackInte
                     // keep track so that the handler can be removed again.
                     final Map<IQRequestHandler, IQRequestHandler> receivedHandler = new HashMap<>();
                     if (receivedHandler.put(needleDetector, oldHandler) != null) {
-                        throw new IllegalStateException("Bug in code: unexpectedly have more than one IQ handler the same detector for the same connection.");
+                        throw new IllegalStateException("Bug in code: unexpectedly have more than one IQ handler with the same detector for the same connection.");
                     }
                     receivedHandlers.put(resourceConnection.getUser(), receivedHandler);
                 }


### PR DESCRIPTION
The RosterIntegrationTest frequently fails. Through debugging, we've established that this happens when the Roster's IQRequestHandler that processes roster pushes is not invoked (even though a corresponding stanza is received).

The source for this problem has been tracked down to RFC6121Section8_5_3_2_3_IqIntegrationTest. This test replaces IQRequestHandlers with an instance that's used by the test. The intention is to restore the handler that was replaced after the test has finished execution.

This commit fixes a bug that prevented the restoration of the original IQRequestHandler.

In the test, the handlers for multiple connections are replaced. The old values, however, are not stored _per connection_. This causes some connections to not get their original handler restored.