### PR TITLE
Skip ad-hoc tests when not provisioned with an admin account

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/xep0133/AbstractAdHocCommandIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0133/AbstractAdHocCommandIntegrationTest.java
@@ -52,10 +52,14 @@ public class AbstractAdHocCommandIntegrationTest extends AbstractSmackIntegratio
     public final AbstractXMPPConnection adminConnection;
     SmackIntegrationTestEnvironment environment;
 
-    public AbstractAdHocCommandIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException, IOException, XMPPException, InterruptedException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    public AbstractAdHocCommandIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException, IOException, XMPPException, InterruptedException, InvocationTargetException, InstantiationException, IllegalAccessException, TestNotPossibleException
+    {
         super(environment);
         this.environment = environment;
 
+        if (sinttestConfiguration.adminAccountUsername == null) {
+            throw new TestNotPossibleException("This test requires an admin account to be configured.");
+        }
         adminConnection = AccountUtilities.spawnNewConnection(environment, sinttestConfiguration);
         adminConnection.connect();
         adminConnection.login(sinttestConfiguration.adminAccountUsername,

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0133/AbstractAdHocCommandIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0133/AbstractAdHocCommandIntegrationTest.java
@@ -58,7 +58,7 @@ public class AbstractAdHocCommandIntegrationTest extends AbstractSmackIntegratio
         this.environment = environment;
 
         if (sinttestConfiguration.adminAccountUsername == null) {
-            throw new TestNotPossibleException("This test requires an admin account to be configured.");
+            throw new TestNotPossibleException("This test requires an admin account to be configured. Configuration instructions available at https://xmpp-interop-testing.github.io/");
         }
         adminConnection = AccountUtilities.spawnNewConnection(environment, sinttestConfiguration);
         adminConnection.connect();

--- a/src/main/java/org/igniterealtime/smack/inttest/xep0133/AdHocCommandIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/xep0133/AdHocCommandIntegrationTest.java
@@ -92,7 +92,7 @@ public class AdHocCommandIntegrationTest extends AbstractAdHocCommandIntegration
     private static final String SHUTDOWN_SERVICE = "http://jabber.org/protocol/admin#shutdown"; //4.31
 
     public AdHocCommandIntegrationTest(SmackIntegrationTestEnvironment environment)
-        throws InvocationTargetException, InstantiationException, IllegalAccessException, SmackException, IOException, XMPPException, InterruptedException {
+        throws InvocationTargetException, InstantiationException, IllegalAccessException, SmackException, IOException, XMPPException, InterruptedException, TestNotPossibleException {
         super(environment);
     }
 


### PR DESCRIPTION
If the runner is configured to use three explicitly named accounts (instead of an admin account that creates accounts as desired), the tests for ad-hoc commands crash. These tests require an administrative account.

In this comment, these tests raise a TestNotPossibleException, rather than cause a crash. This allows other tests to continue.