### PR TITLE
Add config options to provision test accounts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,18 +7,24 @@ TIMEOUT=5000
 usage() {
   cat <<EOF
 Usage:
-    --domain=DOMAIN                       XMPP domain name of server under test. (default: $DOMAIN)
-    --host=HOST                           IP address or DNS name of the XMPP service to run the tests on. (default: $HOST)
-    --timeout=TIMEOUT                     Timeout in milliseconds for any XMPP action (default: $TIMEOUT)
-    --adminAccountUsername=ADMINUSERNAME  Admin username for the service, to create test users (if not using IBR / XEP-0077)
-    --adminAccountPassword=ADMINPASSWORD  Admin password for the service, as above
-    --disabledTests=DISABLEDTESTS         Comma-separated list of tests to skip, e.g. EntityCapsTest,SoftwareInfoIntegrationTest
+    --domain=DOMAIN                              XMPP domain name of server under test. (default: $DOMAIN)
+    --host=HOST                                  IP address or DNS name of the XMPP service to run the tests on. (default: $HOST)
+    --timeout=TIMEOUT                            Timeout in milliseconds for any XMPP action (default: $TIMEOUT)
+    --adminAccountUsername=ADMINUSERNAME         Admin username for the service, to create test users
+    --adminAccountPassword=ADMINPASSWORD         Admin password for the service, as above
+    --accountOneUsername=ACCOUNTONEUSERNAME      The first account name of a set of three accounts used for testing.
+    --accountOnePassword=ACCOUNTONEPASSWORD      The password of the accountOneUsername account.
+    --accountTwoUsername=ACCOUNTTWOUSERNAME      The second account name of a set of three accounts used for testing.
+    --accountTwoPassword=ACCOUNTTWOPASSWORD      The password of the accountTwoUsername account.
+    --accountThreeUsername=ACCOUNTTHREEUSERNAME  The third account name of a set of three accounts used for testing.
+    --accountThreePassword=ACCOUNTTHREEPASSWORD  The password of the accountThreeUsername account.
+    --disabledTests=DISABLEDTESTS                Comma-separated list of tests to skip, e.g. EntityCapsTest,SoftwareInfoIntegrationTest
     --disabledSpecifications=DISABLEDSPECIFICATIONS
-                                          Comma-separated list of specifications to skip, e.g. XEP-0030,XEP-0199
-    --enabledTests=ENABLEDTESTS           Comma-separated list of the only tests to run, e.g. EntityCapsTest,SoftwareInfoIntegrationTest
+                                                 Comma-separated list of specifications to skip, e.g. XEP-0030,XEP-0199
+    --enabledTests=ENABLEDTESTS                  Comma-separated list of the only tests to run, e.g. EntityCapsTest,SoftwareInfoIntegrationTest
     --enabledSpecifications=ENABLEDSPECIFICATIONS
-                                          Comma-separated list of the only specifications to run, e.g. XEP-0030,XEP-0199
-    --help                                This help message
+                                                 Comma-separated list of the only specifications to run, e.g. XEP-0030,XEP-0199
+    --help                                       This help message
 EOF
 }
 
@@ -43,6 +49,30 @@ while [ $# -gt 0 ]; do
     --adminAccountPassword*)
       if [[ "$1" != *=* ]]; then shift; fi
       ADMINACCOUNTPASSWORD="${1#*=}"
+      ;;
+    --accountOneUsername*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTONEUSERNAME="${1#*=}"
+      ;;
+    --accountOnePassword*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTONEPASSWORD="${1#*=}"
+      ;;
+    --accountTwoUsername*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTTWOUSERNAME="${1#*=}"
+      ;;
+    --accountTwoPassword*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTTWOPASSWORD="${1#*=}"
+      ;;
+    --accountThreeUsername*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTTHREEUSERNAME="${1#*=}"
+      ;;
+    --accountThreePassword*)
+      if [[ "$1" != *=* ]]; then shift; fi
+      ACCOUNTTHREEPASSWORD="${1#*=}"
       ;;
     --disabledTests*)
       if [[ "$1" != *=* ]]; then shift; fi
@@ -76,6 +106,13 @@ done
 if [ ! -v DOMAIN ]; then echo "Domain is not set"; exit 1; fi
 if [ ! -v ADMINACCOUNTUSERNAME ] && [ -v ADMINACCOUNTPASSWORD ]; then echo "Admin username is not set, but password is. Credentials must be specified as a pair"; exit 1; fi
 if [ ! -v ADMINACCOUNTPASSWORD ] && [ -v ADMINACCOUNTUSERNAME ]; then echo "Admin password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTONEUSERNAME ] && [ -v $ACCOUNTONEPASSWORD ]; then echo "Test account 'one' username is not set, but password is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTONEPASSWORD ] && [ -v $ACCOUNTONEUSERNAME ]; then echo "Test account 'one' password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTTWOUSERNAME ] && [ -v $ACCOUNTTWOPASSWORD ]; then echo "Test account 'two' username is not set, but password is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTTWOPASSWORD ] && [ -v $ACCOUNTTWOUSERNAME ]; then echo "Test account 'two' password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTTHREEUSERNAME ] && [ -v $ACCOUNTTHREEPASSWORD ]; then echo "Test account 'three' username is not set, but password is. Credentials must be specified as a pair"; exit 1; fi
+if [ ! -v $ACCOUNTTHREEPASSWORD ] && [ -v $ACCOUNTTHREEUSERNAME ]; then echo "Test account 'three' password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
+# TODO check if _all three_ accounts are provisioned (or none at all).
 
 JAVACMD=()
 JAVACMD+=("java")
@@ -88,6 +125,24 @@ if [ "$ADMINACCOUNTUSERNAME" != "" ]; then
 fi
 if [ "$ADMINACCOUNTPASSWORD" != "" ]; then
   JAVACMD+=("-Dsinttest.adminAccountPassword=$ADMINACCOUNTPASSWORD")
+fi
+if [ "$ACCOUNTONEUSERNAME" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountOneUsername=$ACCOUNTONEUSERNAME")
+fi
+if [ "$ACCOUNTONEPASSWORD" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountOnePassword=$ACCOUNTONEPASSWORD")
+fi
+if [ "$ACCOUNTTWOUSERNAME" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountTwoUsername=$ACCOUNTTWOUSERNAME")
+fi
+if [ "$ACCOUNTTWOPASSWORD" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountTwoPassword=$ACCOUNTTWOPASSWORD")
+fi
+if [ "$ACCOUNTTHREEUSERNAME" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountThreeUsername=$ACCOUNTTHREEUSERNAME")
+fi
+if [ "$ACCOUNTTHREEPASSWORD" != "" ]; then
+  JAVACMD+=("-Dsinttest.accountThreePassword=$ACCOUNTTHREEPASSWORD")
 fi
 JAVACMD+=("-Dsinttest.enabledConnections=tcp")
 JAVACMD+=("-Dsinttest.dnsResolver=javax")


### PR DESCRIPTION
Instead of using an admin account or in-band registration to provision test accounts, the runner can be configured with three distinct test accounts.

In this commit, new input parameters are added to the entrypoint script for the containers that can be used by an end-user to configure those accounts.

fixes #126

This corresponds to the functionality that is documented on the website in https://github.com/XMPP-Interop-Testing/xmpp-interop-testing.github.io/pull/33