### PR TITLE
Add entrypoint check for exactly 0 or 3 test accounts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ Dockerfile
 .editorconfig
 .settings
 .vscode
+test
 
 # Any already built stuff.
 target

--- a/.github/workflows/entrypoint-test.yml
+++ b/.github/workflows/entrypoint-test.yml
@@ -10,8 +10,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Bats
         run: |
+          # Skip installing package docs {makes the man-db trigger much faster)
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
+          EOF
+          
           sudo apt update
           sudo apt install -y bats bats-assert bats-support
+      - name: Setup Bats and Bats-libs
+        uses: bats-core/bats-action@3.0.1
+        id: setup-bats
+        with:
+          support-install: "true"
+          assert-install: "true"
+          detik-install: "false"
+          file-install: "false"
       - name: Run entrypoint.bats
         run: |
           export BATS_TEST_MODE=true  # Disable java execution in the entrypoint script

--- a/.github/workflows/entrypoint-test.yml
+++ b/.github/workflows/entrypoint-test.yml
@@ -1,0 +1,18 @@
+name: Test Entrypoint Script
+
+on: [pull_request]
+
+jobs:
+  entrypoint-bats:
+    name: Test Entrypoint with BATS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Bats
+        run: |
+          sudo apt update
+          sudo apt install -y bats bats-assert bats-support
+      - name: Run entrypoint.bats
+        run: |
+          export BATS_TEST_MODE=true  # Disable java execution in the entrypoint script
+          bats ./test/entrypoint.bats

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -124,6 +124,12 @@ if [[ $ACCOUNT_COUNT -ne 0 ]] && [[ $ACCOUNT_COUNT -ne 3 ]]; then
     exit 1
 fi
 
+if [[ $ACCOUNT_COUNT -eq 3 ]] && [[ -n "$ADMINACCOUNTUSERNAME" ]]; then
+    echo "You can specify either 3 individual test accounts or an admin account, or neither, but not both."
+    exit 1
+fi
+
+
 JAVACMD=()
 JAVACMD+=("java")
 JAVACMD+=("-Dsinttest.service=$DOMAIN")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -183,4 +183,9 @@ JAVACMD+=("/usr/local/sintse/sintse.jar")
 
 echo "Running: ${JAVACMD[@]}"
 
+if [ "$BATS_TEST_MODE" == "true" ]; then
+  # In BATS test mode, don't execute - we've already printed what we would've done just above.
+  exit 0
+fi
+
 "${JAVACMD[@]}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,7 +112,17 @@ if [ ! -v $ACCOUNTTWOUSERNAME ] && [ -v $ACCOUNTTWOPASSWORD ]; then echo "Test a
 if [ ! -v $ACCOUNTTWOPASSWORD ] && [ -v $ACCOUNTTWOUSERNAME ]; then echo "Test account 'two' password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
 if [ ! -v $ACCOUNTTHREEUSERNAME ] && [ -v $ACCOUNTTHREEPASSWORD ]; then echo "Test account 'three' username is not set, but password is. Credentials must be specified as a pair"; exit 1; fi
 if [ ! -v $ACCOUNTTHREEPASSWORD ] && [ -v $ACCOUNTTHREEUSERNAME ]; then echo "Test account 'three' password is not set, but username is. Credentials must be specified as a pair"; exit 1; fi
-# TODO check if _all three_ accounts are provisioned (or none at all).
+
+# Check if _all three_ accounts are provisioned (or none at all).
+ACCOUNT_COUNT=0
+if [[ -n "$ACCOUNTONEUSERNAME" ]]; then ((ACCOUNT_COUNT++)); fi
+if [[ -n "$ACCOUNTTWOUSERNAME" ]]; then ((ACCOUNT_COUNT++)); fi
+if [[ -n "$ACCOUNTTHREEUSERNAME" ]]; then ((ACCOUNT_COUNT++)); fi
+
+if [[ $ACCOUNT_COUNT -ne 0 ]] && [[ $ACCOUNT_COUNT -ne 3 ]]; then
+    echo "You must specify three test accounts, or none at all"
+    exit 1
+fi
 
 JAVACMD=()
 JAVACMD+=("java")

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -1,0 +1,53 @@
+#!/usr/bin/env bats
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+setup() {
+  SCRIPT="$(pwd)/entrypoint.sh"
+  chmod +x "$SCRIPT"
+}
+
+@test "prints usage with --help" {
+  run "$SCRIPT" --help
+  assert_success
+  assert_output --partial "Usage:"
+}
+
+@test "fails with invalid argument" {
+  run "$SCRIPT" --notarealflag
+  assert_failure
+  assert_output --partial "Error: Invalid argument"
+}
+
+@test "fails if only one account is specified" {
+  run "$SCRIPT" --accountOneUsername=foo --accountOnePassword=bar
+  assert_failure
+  assert_output --partial "You must specify three test accounts, or none at all"
+}
+
+@test "fails if three accounts and admin specified" {
+  run "$SCRIPT" --accountOneUsername=foo --accountOnePassword=bar --accountTwoUsername=foo2 --accountTwoPassword=bar2 --accountThreeUsername=foo3 --accountThreePassword=bar3 --adminAccountUsername=admin --adminAccountPassword=adminpw
+  assert_failure
+  assert_output --partial "You can specify either 3 individual test accounts or an admin account, or neither, but not both."
+}
+
+@test "succeeds with three accounts only" {
+  run "$SCRIPT" --accountOneUsername=foo --accountOnePassword=bar --accountTwoUsername=foo2 --accountTwoPassword=bar2 --accountThreeUsername=foo3 --accountThreePassword=bar3
+  assert_success
+  assert_output --partial "Running: java -Dsinttest"
+  assert_output --partial "-Dsinttest.accountOneUsername=foo -Dsinttest.accountOnePassword=bar -Dsinttest.accountTwoUsername=foo2 -Dsinttest.accountTwoPassword=bar2 -Dsinttest.accountThreeUsername=foo3 -Dsinttest.accountThreePassword=bar3"
+}
+
+@test "succeeds with admin only" {
+  run "$SCRIPT" --adminAccountUsername=admin --adminAccountPassword=adminpw
+  assert_success
+  assert_output --partial "Running: java -Dsinttest"
+  assert_output --partial "-Dsinttest.adminAccountUsername=admin -Dsinttest.adminAccountPassword=adminpw"
+}
+
+@test "succeeds with neither an admin account or manually specified accounts (IBR mode)" {
+  run "$SCRIPT"
+  assert_success
+  assert_output --partial "Running: java -Dsinttest"
+}

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -32,6 +32,12 @@ setup() {
   assert_output --partial "You can specify either 3 individual test accounts or an admin account, or neither, but not both."
 }
 
+@test "fails if admin username is specified without a password" {
+  run "$SCRIPT" --adminAccountUsername=foo
+  assert_failure
+  assert_output --partial "Admin password is not set, but username is. Credentials must be specified as a pair"
+}
+
 @test "succeeds with three accounts only" {
   run "$SCRIPT" --accountOneUsername=foo --accountOnePassword=bar --accountTwoUsername=foo2 --accountTwoPassword=bar2 --accountThreeUsername=foo3 --accountThreePassword=bar3
   assert_success
@@ -50,4 +56,18 @@ setup() {
   run "$SCRIPT"
   assert_success
   assert_output --partial "Running: java -Dsinttest"
+}
+
+@test "succeeds when parameters are provided with spaces" {
+  run "$SCRIPT" --domain test.example
+  assert_success
+  assert_output --partial "Running: java -Dsinttest"
+  assert_output --partial "-Dsinttest.service=test.example"
+}
+
+@test "succeeds when parameters are provided with equals" {
+  run "$SCRIPT" --domain=test.example
+  assert_success
+  assert_output --partial "Running: java -Dsinttest"
+  assert_output --partial "-Dsinttest.service=test.example"
 }


### PR DESCRIPTION
Adds:
- Entrypoint check for providing 0 or 3 test accounts, nothing in between
- Entrypoint check for providing test accounts or an admin account, not both
- BATS tests for the entrypoint script, given that we've accumulated logic for it
- GitHub Action to run the BATS tests

Fixes #128 

