### PR TITLE
CI: add tests for each account provisioning method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build-java:
-    name: Build
+    name: Build the test suite
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -30,8 +30,9 @@ jobs:
           name: smack-tests
           path: target/smack-sint-server-extensions-*-jar-with-dependencies.jar
           retention-days: 1
-  test-java:
-    name: Test
+
+  test-java-admin:
+    name: Test the suite against an XMPP server (using admin account)
     runs-on: ubuntu-latest
     needs: build-java
     steps:
@@ -63,23 +64,143 @@ jobs:
           -Dsinttest.adminAccountPassword=admin \
           -Dsinttest.enabledConnections=tcp \
           -Dsinttest.dnsResolver=javax \
-          -Dsinttest.enabledTests="VCardTempIntegrationTest" \
+          -Dsinttest.enabledTests="VCardTempIntegrationTest,PingIntegrationTest" \
           -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
           -Dsinttest.debugger=org.igniterealtime.smack.inttest.util.ModifiedStandardSinttestDebuggerMetaFactory \
-          -DlogDir=./target/logs \
+          -DlogDir=./logs \
           -jar $JARFILE
         shell: bash
       - name: Expose XMPP debug logs
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails
         with:
-          name: XMPP debug logs
+          name: XMPP debug logs (for test ID 'provisioning-admin')
           path: logs/*
       - name: Expose Openfire logs
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails
         with:
-          name: Openfire server logs
+          name: Openfire server logs (for test ID 'provisioning-admin')
+          path: openfire/logs/*
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/test-results.xml'
+          suite_regex: '*'
+          include_passed: true
+          detailed_summary: true
+  test-java-accounts:
+    name: Test the suite against an XMPP server (using explicit accounts)
+    runs-on: ubuntu-latest
+    needs: build-java
+    steps:
+      - name: Download the built artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: smack-tests
+          path: .
+      - name: Start a test server (Openfire daily)
+        uses: igniterealtime/launch-openfire-action@main
+        with:
+          daily: 'true'
+      - name: Run the tests
+        run: |
+          # Get the jar file by globbing on the version
+          JAR_MATCHES=(smack-sint-server-extensions-*-jar-with-dependencies.jar)
+          JARFILE=${JAR_MATCHES[0]}
+
+          # Run the tests the same way the action does
+          # Borrowing from:
+          #  - https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-action/blob/main/action.yml
+          #  - https://github.com/igniterealtime/Openfire/blob/ddf144c4ff3b0f753c4087c1e197dfc2bab324a9/.github/workflows/continuous-integration-workflow.yml#L199-L205
+          java \
+          -Dsinttest.service="example.org" \
+          -Dsinttest.host="127.0.0.1" \
+          -Dsinttest.securityMode=disabled \
+          -Dsinttest.replyTimeout=5000 \
+          -Dsinttest.accountOneUsername="jane" \
+          -Dsinttest.accountOnePassword="secret" \
+          -Dsinttest.accountTwoUsername="juan" \
+          -Dsinttest.accountTwoPassword="secret" \
+          -Dsinttest.accountThreeUsername="john" \
+          -Dsinttest.accountThreePassword="secret" \
+          -Dsinttest.enabledConnections=tcp \
+          -Dsinttest.dnsResolver=javax \
+          -Dsinttest.enabledTests="VCardTempIntegrationTest,PingIntegrationTest" \
+          -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
+          -Dsinttest.debugger=org.igniterealtime.smack.inttest.util.ModifiedStandardSinttestDebuggerMetaFactory \
+          -DlogDir=./logs \
+          -jar $JARFILE
+        shell: bash
+      - name: Expose XMPP debug logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: XMPP debug logs (for test ID 'provisioning-static-accounts')
+          path: logs/*
+      - name: Expose Openfire logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: Openfire server logs (for test ID 'provisioning-static-accounts')
+          path: openfire/logs/*
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/test-results.xml'
+          suite_regex: '*'
+          include_passed: true
+          detailed_summary: true
+  test-java-ibr:
+    name: Test the suite against an XMPP server (using XEP-0077 In-Band Registration)
+    runs-on: ubuntu-latest
+    needs: build-java
+    steps:
+      - name: Download the built artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: smack-tests
+          path: .
+      - name: Start a test server (Openfire daily)
+        uses: igniterealtime/launch-openfire-action@main
+        with:
+          daily: 'true'
+      - name: Run the tests
+        run: |
+          # Get the jar file by globbing on the version
+          JAR_MATCHES=(smack-sint-server-extensions-*-jar-with-dependencies.jar)
+          JARFILE=${JAR_MATCHES[0]}
+
+          # Run the tests the same way the action does
+          # Borrowing from:
+          #  - https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-action/blob/main/action.yml
+          #  - https://github.com/igniterealtime/Openfire/blob/ddf144c4ff3b0f753c4087c1e197dfc2bab324a9/.github/workflows/continuous-integration-workflow.yml#L199-L205
+          java \
+          -Dsinttest.service="example.org" \
+          -Dsinttest.host="127.0.0.1" \
+          -Dsinttest.securityMode=disabled \
+          -Dsinttest.replyTimeout=5000 \
+          -Dsinttest.enabledConnections=tcp \
+          -Dsinttest.dnsResolver=javax \
+          -Dsinttest.enabledTests="VCardTempIntegrationTest,PingIntegrationTest" \
+          -Dsinttest.testRunResultProcessors=org.igniterealtime.smack.inttest.util.StdOutTestRunResultProcessor,org.igniterealtime.smack.inttest.util.JUnitXmlTestRunResultProcessor \
+          -Dsinttest.debugger=org.igniterealtime.smack.inttest.util.ModifiedStandardSinttestDebuggerMetaFactory \
+          -DlogDir=./logs \
+          -jar $JARFILE
+        shell: bash
+      - name: Expose XMPP debug logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: XMPP debug logs (for test ID 'provisioning-ibr')
+          path: logs/*
+      - name: Expose Openfire logs
+        uses: actions/upload-artifact@v4
+        if: always() # always run even if the previous step fails
+        with:
+          name: Openfire server logs (for test ID 'provisioning-ibr')
           path: openfire/logs/*
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
@@ -91,7 +212,7 @@ jobs:
           detailed_summary: true
 
   build-and-test-docker:
-    name: Build Docker image
+    name: Build & Test the Docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -116,21 +237,28 @@ jobs:
             --timeout=5000 \
             --adminAccountUsername=admin \
             --adminAccountPassword=admin \
-            --enabledTests="VCardTempIntegrationTest"
+            --enabledTests="VCardTempIntegrationTest,PingIntegrationTest"
         shell: bash
-
       - name: Expose XMPP debug logs
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails
         with:
-          name: XMPP debug logs from Docker
+          name: XMPP debug logs from Docker (for test ID 'provisioning-admin')
           path: xmpplogs/*
       - name: Expose Openfire logs
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails
         with:
-          name: Openfire server logs from Docker test
+          name: Openfire server logs from Docker test (for test ID 'provisioning-admin')
           path: openfire/logs/*
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always() # always run even if the previous step fails
+        with:
+          report_paths: '**/test-results.xml'
+          suite_regex: '*'
+          include_passed: true
+          detailed_summary: true
 
   build-podman:
     name: Build with Podman

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,44 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-java
     steps:
-      - name: Checkout Openfire actions e.g. 'startCIServer'
-        uses: actions/checkout@v4
-        with:
-          repository: igniterealtime/Openfire
-          sparse-checkout: |
-            .github
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: openfire.tar.gz
-          key: openfire-daily-${{env.NOW}}
-      - name: Download a recent Openfire daily build.
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          # This tries to find the most recent daily build, going back 30 days if none are available.
-          #Note that the cache above will cause whatever build that's download to be considered 'todays' build.
-          for i in $(seq 0 30); do
-            STAMP=`date --date="$i day ago" +%F`;
-            echo "Attempting to download Openfire build for $STAMP"
-            curl --fail -L "https://download.igniterealtime.org/openfire/dailybuilds/openfire_$STAMP.tar.gz" -o openfire.tar.gz && break
-          done
-      - name: Extract Openfire
-        run: |
-          tar -xzf openfire.tar.gz
-      - name: Start CI server from distribution
-        id: startCIServer
-        uses: ./.github/actions/startserver-action
-        with:
-          distBaseDir: './openfire'
-          domain: 'example.org'
-          ip: '127.0.0.1'
       - name: Download the built artifacts
         uses: actions/download-artifact@v4
         with:
           name: smack-tests
           path: .
+      - name: Start a test server (Openfire daily)
+        uses: igniterealtime/launch-openfire-action@main
+        with:
+          daily: 'true'
       - name: Run the tests
         run: |
           # Get the jar file by globbing on the version
@@ -130,41 +101,10 @@ jobs:
           context: .
           load: true
           tags: xmpp_interop_tests:testing
-
-      - name: Checkout Openfire actions e.g. 'startCIServer'
-        uses: actions/checkout@v4
+      - name: Start a test server (Openfire daily)
+        uses: igniterealtime/launch-openfire-action@main
         with:
-          repository: igniterealtime/Openfire
-          sparse-checkout: |
-            .github
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: openfire.tar.gz
-          key: openfire-daily-${{env.NOW}}
-      - name: Download a recent Openfire daily build.
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          # This tries to find the most recent daily build, going back 30 days if none are available.
-          #Note that the cache above will cause whatever build that's download to be considered 'todays' build.
-          for i in $(seq 0 30); do
-            STAMP=`date --date="$i day ago" +%F`;
-            echo "Attempting to download Openfire build for $STAMP"
-            curl --fail -L "https://download.igniterealtime.org/openfire/dailybuilds/openfire_$STAMP.tar.gz" -o openfire.tar.gz && break
-          done
-      - name: Extract Openfire
-        run: |
-          tar -xzf openfire.tar.gz
-      - name: Start CI server from distribution
-        id: startCIServer
-        uses: ./.github/actions/startserver-action
-        with:
-          distBaseDir: './openfire'
-          domain: 'example.org'
-          ip: '127.0.0.1'
-
+          daily: 'true'
       - name: Run the tests
         run: |
           docker run \


### PR DESCRIPTION
Prior to this PR, the workflows of this repository test the built java version, as well as one of the containers, against a running XMPP server.

In this PR, that test is expanded with new tests, that each use different test account provisioning options (#126)

As an aside, this PR also contains the following change: Replace boilerplate code with GitHub Action

The continuous integration workflow starts an Openfire server for testing. In this commit, all of the related instructions are replaced with the GitHub action that is provided in https://github.com/igniterealtime/launch-openfire-action which does the same thing.