### PR TITLE
Add downstream trigger for Jenkins repo

### DIFF
--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -55,6 +55,21 @@ jobs:
                 https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-circleci-orb/dispatches \
                 -d '{"event_type":"trigger-workflow","client_payload":{"version":"'"${{ needs.prepare.outputs.version }}"'"}}'
 
+  jenkins:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Call downstream job for Jenkinsfile
+        run: |
+          curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_JENKINS_REPO }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-jenkins/dispatches \
+              -d '{"event_type":"trigger-workflow","client_payload":{"version":"'"${{ needs.prepare.outputs.version }}"'"}}'
+
+
   gitlab-component:
     runs-on: ubuntu-latest
     needs: prepare


### PR DESCRIPTION
This is largely a copy-paste of other the GitHub jobs above it

This matches the other part in https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-jenkins/pull/7

Introduces a new TOKEN_FOR_JENKINS_REPO secret, another PAT, configured identically to the one in #71  