### PR TITLE
Add downstream trigger for Drone repo

### DIFF
--- a/.github/workflows/downstream_releases.yml
+++ b/.github/workflows/downstream_releases.yml
@@ -70,6 +70,21 @@ jobs:
               -d '{"event_type":"trigger-workflow","client_payload":{"version":"'"${{ needs.prepare.outputs.version }}"'"}}'
 
 
+  drone:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Call downstream job for Drone plugin
+        run: |
+          curl -L \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${{ secrets.TOKEN_FOR_DRONE_REPO }}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/XMPP-Interop-Testing/xmpp-interop-tests-drone-plugin/dispatches \
+              -d '{"event_type":"trigger-workflow","client_payload":{"version":"'"${{ needs.prepare.outputs.version }}"'"}}'
+
+
   gitlab-component:
     runs-on: ubuntu-latest
     needs: prepare


### PR DESCRIPTION
Matching part to https://github.com/XMPP-Interop-Testing/xmpp-interop-tests-drone-plugin/pull/13

Introduces a new TOKEN_FOR_DRONE_REPO secret, another PAT, configured identically to the one in https://github.com/XMPP-Interop-Testing/smack-sint-server-extensions/pull/71