### PR TITLE
No longer check for `jabber:iq:roster` disco#info feature

### DIFF
--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_1_3_IqIntegrationTest.java
@@ -404,10 +404,6 @@ public class RFC6121Section8_5_2_1_3_IqIntegrationTest extends AbstractSmackInte
      */
     public void doTestSupportedIQ(final IQ.Type iqType, final List<Integer> resourcePriorities) throws Exception
     {
-        if (!ServiceDiscoveryManager.getInstanceFor(conOne).supportsFeature(conOne.getXMPPServiceDomain(), "jabber:iq:roster")) {
-            throw new TestNotPossibleException("The 'jabber:iq:roster' feature is not advertised by the server");
-        }
-
         final RosterPacket stanzaToSend = new RosterPacket();
         stanzaToSend.setType(iqType); // Neither a 'set' nor 'get' roster request to another person's JID is expected to change state of their roster (so it can be considered quite safe to use for testing purposes).
         doTest(stanzaToSend, resourcePriorities, (stanzasReceivedByRecipient, testStanza, testResponse) ->

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_2_2_3_IqIntegrationTest.java
@@ -163,10 +163,6 @@ public class RFC6121Section8_5_2_2_3_IqIntegrationTest extends AbstractSmackInte
      */
     public void doTestSupportedIQ(final IQ.Type iqType) throws Exception
     {
-        if (!ServiceDiscoveryManager.getInstanceFor(conOne).supportsFeature(conOne.getXMPPServiceDomain(), "jabber:iq:roster")) {
-            throw new TestNotPossibleException("The 'jabber:iq:roster' feature is not advertised by the server");
-        }
-
         // Setup test fixture.
         final RosterPacket testStanza = new RosterPacket();
         testStanza.setType(iqType); // Neither a 'set' nor 'get' roster request to another person's JID is expected to change state of their roster (so it can be considered quite safe to use for testing purposes).

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_1_IntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_1_IntegrationTest.java
@@ -109,10 +109,6 @@ public class RFC6121Section8_5_3_1_IntegrationTest extends AbstractSmackIntegrat
     @SmackIntegrationTest(section = "8.5.3.1", quote = "If the domainpart of the JID contained in the 'to' attribute of an inbound stanza matches one of the configured domains of the server itself and the JID contained in the 'to' attribute is of the form <localpart@domainpart/resourcepart>, then the server MUST adhere to the following rules. [...] If an available resource or connected resource exactly matches the full JID, how the stanza is processed depends on the stanza type. [...] For an IQ stanza of type \"result\" or \"error\", the server MUST deliver the stanza to the resource.")
     public void testIqErrorSupported() throws Exception
     {
-        if (!ServiceDiscoveryManager.getInstanceFor(conOne).supportsFeature(conOne.getXMPPServiceDomain(), "jabber:iq:roster")) {
-            throw new TestNotPossibleException("The 'jabber:iq:roster' feature is not advertised by the server");
-        }
-
         // Setup test fixture.
         final RosterPacket stanzaToSend = new RosterPacket();
         stanzaToSend.setType(IQ.Type.error);
@@ -135,10 +131,6 @@ public class RFC6121Section8_5_3_1_IntegrationTest extends AbstractSmackIntegrat
     @SmackIntegrationTest(section = "8.5.3.1", quote = "If the domainpart of the JID contained in the 'to' attribute of an inbound stanza matches one of the configured domains of the server itself and the JID contained in the 'to' attribute is of the form <localpart@domainpart/resourcepart>, then the server MUST adhere to the following rules. [...] If an available resource or connected resource exactly matches the full JID, how the stanza is processed depends on the stanza type. [...] For an IQ stanza of type \"result\" or \"error\", the server MUST deliver the stanza to the resource.")
     public void testIqResultSupported() throws Exception
     {
-        if (!ServiceDiscoveryManager.getInstanceFor(conOne).supportsFeature(conOne.getXMPPServiceDomain(), "jabber:iq:roster")) {
-            throw new TestNotPossibleException("The 'jabber:iq:roster' feature is not advertised by the server");
-        }
-
         // Setup test fixture.
         final RosterPacket stanzaToSend = new RosterPacket();
         stanzaToSend.setType(IQ.Type.result);

--- a/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_3_IqIntegrationTest.java
+++ b/src/main/java/org/igniterealtime/smack/inttest/rfc6121/section8/RFC6121Section8_5_3_2_3_IqIntegrationTest.java
@@ -389,10 +389,6 @@ public class RFC6121Section8_5_3_2_3_IqIntegrationTest extends AbstractSmackInte
      */
     public void doTestSupportedIQ(final IQ.Type iqType, final List<Integer> resourcePriorities) throws Exception
     {
-        if (!ServiceDiscoveryManager.getInstanceFor(conOne).supportsFeature(conOne.getXMPPServiceDomain(), "jabber:iq:roster")) {
-            throw new TestNotPossibleException("The 'jabber:iq:roster' feature is not advertised by the server");
-        }
-
         final RosterPacket stanzaToSend = new RosterPacket();
         stanzaToSend.setType(iqType); // Neither a 'set' nor 'get' roster request to another person's JID is expected to change state of their roster (so it can be considered quite safe to use for testing purposes).
         doTest(stanzaToSend, resourcePriorities);


### PR DESCRIPTION
The XSF Registrar registers jabber:iq:roster as a service discovery feature in https://xmpp.org/registrar/disco-features.html but none of the relevant RFCs mandate that this feature is to be advertised.

RFC 6121 section 12 suggests that support of roster (get/set) is mandatory for servers.

Some of our tests check for this feature to be advertised, and throw a TestNotPossible if that's not the case. This check should be removed.

fixes #144