### PR TITLE
Bump version identifier of XEP-0045 from 1.35.1 to 1.35.2

### DIFF
--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#ban">XEP-0045 Section 9.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminBanIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminBanListIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyban">XEP-0045 Section 9.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminBanListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminBanListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantMemberIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmember">XEP-0045 Section 9.3</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminGrantMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantMemberIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminGrantModeratorIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantmod">XEP-0045 Section 9.6</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminGrantModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminGrantModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminMemberListIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymember">XEP-0045 Section 9.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminMemberListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminMemberListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminModeratorListIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifymod">XEP-0045 Section 9.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminModeratorListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminModeratorListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeMemberIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemember">XEP-0045 Section 9.4</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminRevokeMemberIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeMemberIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatAdminRevokeModeratorIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokemod">XEP-0045 Section 9.7</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatAdminRevokeModeratorIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatAdminRevokeModeratorIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatInvitationIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#invite">XEP-0045 Section 7.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatInvitationIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatInvitationIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorKickIntegrationTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#kick">XEP-0045 Section 8.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatModeratorKickIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatModeratorKickIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatModeratorSubjectModIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#subject-mod">XEP-0045 Section 8.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatModeratorSubjectModIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatModeratorSubjectModIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOccupantPMIntegrationTest.java
@@ -48,7 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#privatemessage">XEP-0045 Section 7.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOccupantPMIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOccupantPMIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerAdminListIntegrationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyadmin">XEP-0045 Section 10.8</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerAdminListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerAdminListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerConfigRoomIntegrationTest.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#roomconfig">XEP-0045 Section 10.2</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerConfigRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerConfigRoomIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerCreateRoomIntegrationTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#createroom">XEP-0045 Section 10.1</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerCreateRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerCreateRoomIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerDestroyRoomIntegrationTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#destroyroom">XEP-0045 Section 10.9</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerDestroyRoomIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerDestroyRoomIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantAdminIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantadmin">XEP-0045 Section 10.6</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerGrantAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerGrantAdminIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerGrantOwnerIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#grantowner">XEP-0045 Section 10.3</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerGrantOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerGrantOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#owner">XEP-0045 Section 10</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerOwnerListIntegrationTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#modifyowner">XEP-0045 Section 10.5</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerOwnerListIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerOwnerListIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeAdminIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeadmin">XEP-0045 Section 10.7</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerRevokeAdminIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerRevokeAdminIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatOwnerRevokeOwnerIntegrationTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#revokeowner">XEP-0045 Section 10.4</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatOwnerRevokeOwnerIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatOwnerRevokeOwnerIntegrationTest(SmackIntegrationTestEnvironment environment)

--- a/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
+++ b/src/main/java/org/jivesoftware/smackx/muc/MultiUserChatSecurityConsiderationsIntegrationTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @see <a href="https://xmpp.org/extensions/xep-0045.html#security">XEP-0045 Section 10</a>
  */
-@SpecificationReference(document = "XEP-0045", version = "1.35.1")
+@SpecificationReference(document = "XEP-0045", version = "1.35.2")
 public class MultiUserChatSecurityConsiderationsIntegrationTest extends AbstractMultiUserChatIntegrationTest
 {
     public MultiUserChatSecurityConsiderationsIntegrationTest(SmackIntegrationTestEnvironment environment) throws SmackException.NoResponseException, XMPPException.XMPPErrorException, SmackException.NotConnectedException, InterruptedException, TestNotPossibleException, MultiUserChatException.MucAlreadyJoinedException, MultiUserChatException.MissingMucCreationAcknowledgeException, MultiUserChatException.NotAMucServiceException, XmppStringprepException

--- a/xmpp-interop-testing.doap
+++ b/xmpp-interop-testing.doap
@@ -43,7 +43,7 @@
         <implements>
             <xmpp:SupportedXep>
                 <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0045.html"/>
-                <xmpp:version>1.35.1</xmpp:version>
+                <xmpp:version>1.35.2</xmpp:version>
             </xmpp:SupportedXep>
         </implements>
         <implements>


### PR DESCRIPTION
This doesn't require changes in the implementations of tests in this project.

fixes #163